### PR TITLE
fix: AppImage blank UI on Fedora 43 (Wayland) - exclude bundled wayla…

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "build:linux": "NO_STRIP=1 APPIMAGE_EXTRACT_AND_RUN=1 LINUXDEPLOY_EXCLUDE_LIBS=libwayland-client.so.0:libwayland-cursor.so.0:libwayland-egl.so.1:libwayland-server.so.0 npm run tauri build"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.18",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ tauri = { version = "2", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
-zip = "7.4.0"
+zip = "2.4.2"
 flate2 = "1.0"
 tar = "0.4"
 tokio = { version = "1.49.0", features = ["full"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,9 @@ use std::sync::Mutex;
 use tauri::Manager;
 use tokio::process::Child;
 
+#[cfg(target_os = "linux")]
+use std::os::unix::process::CommandExt;
+
 pub struct ScrcpyState {
     pub processes: Mutex<HashMap<String, Child>>,
 }
@@ -15,6 +18,40 @@ pub fn run() {
     {
         if std::env::var("WEBKIT_DISABLE_COMPOSITING_MODE").is_err() {
             std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        }
+
+        // Workaround for AppImage blank UI on Fedora/Wayland
+        // Preload the host's libwayland-client.so.0 to prevent conflicts with bundled version
+        // Checking whether it is an AppImage or not by checking APPDIR environment variable
+        if std::env::var("APPDIR").is_ok() && std::env::var("WAYLAND_DISPLAY").is_ok() {
+            let preload = std::env::var("LD_PRELOAD").unwrap_or_default();
+            if !preload.contains("libwayland-client.so.0") {
+                // checking host native libwayland-client.so.0 is loaded or not by checking LD_PRELOAD environment variable
+                let paths = [
+                    "/usr/lib64/libwayland-client.so.0",
+                    "/usr/lib/x86_64-linux-gnu/libwayland-client.so.0",
+                    "/usr/lib/libwayland-client.so.0",
+                ];
+                for path in paths {
+                    // if host native libwayland-client.so.0 is found it will be loaded instead of bundled version
+                    if std::path::Path::new(path).exists() {
+                        let mut new_preload = preload;
+                        if !new_preload.is_empty() {
+                            new_preload.push(':');
+                        }
+                        new_preload.push_str(path);
+                        std::env::set_var("LD_PRELOAD", &new_preload);
+
+                        let current_exe = std::env::current_exe().unwrap_or_else(|_| {
+                            std::path::PathBuf::from(std::env::args().next().unwrap())
+                        });
+                        let mut cmd = std::process::Command::new(current_exe);
+                        cmd.args(std::env::args().skip(1));
+                        let _ = cmd.exec();
+                        break;
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
…nd libs

- lib.rs: runtime self-restart with host libwayland-client.so.0 when running as AppImage on Wayland (checks /usr/lib64, /usr/lib/x86_64-linux-gnu, /usr/lib paths for cross-distro compatibility)
- package.json: add build:linux script with NO_STRIP=1, APPIMAGE_EXTRACT_AND_RUN=1, and LINUXDEPLOY_EXCLUDE_LIBS to exclude bundled wayland libs at build time
- Cargo.toml: bump zip from yanked 7.4.0 to stable 2.4.2

Fixes #29