### PR TITLE
Add light mode and system color mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,8 @@ function App() {
     setConfig,
     theme,
     setTheme,
+    colorMode,
+    setColorMode,
     pushFile,
     installApk,
     historyDevices,
@@ -217,7 +219,7 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <div className="min-h-screen text-zinc-200 font-sans selection:bg-primary selection:text-white overflow-hidden flex flex-col transition-opacity duration-1000 ease-in-out" style={{ backgroundColor: 'var(--bg-base)', opacity: 0, animation: 'fadeIn 0.8s ease-out forwards' }}>
+      <div className="min-h-screen font-sans selection:bg-primary selection:text-on-primary overflow-hidden flex flex-col transition-opacity duration-1000 ease-in-out" style={{ backgroundColor: 'var(--bg-base)', color: 'var(--text-base)', opacity: 0, animation: 'fadeIn 0.8s ease-out forwards' }}>
         <style>{`
           @keyframes fadeIn {
             from { opacity: 0; transform: translateY(5px); }
@@ -231,6 +233,8 @@ function App() {
           <Header
             onThemeChange={setTheme}
             currentTheme={theme}
+            colorMode={colorMode}
+            onColorModeChange={setColorMode}
             binaryStatus={scrcpyStatus}
             onDownload={downloadScrcpy}
             onSetPath={handleSetPath}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
-import { Download, FolderOpen, RefreshCcw, Palette, HelpCircle, X, ExternalLink, Languages, ChevronDown } from 'lucide-react';
+import { Download, FolderOpen, RefreshCcw, Palette, HelpCircle, X, ExternalLink, Languages, ChevronDown, Sun, Moon, Monitor } from 'lucide-react';
 import { SUPPORTED_LOCALES, useI18n, type Locale } from '../i18n';
 
 interface HeaderProps {
     onThemeChange: (theme: string) => void;
     currentTheme: string;
+    colorMode: 'light' | 'dark' | 'system';
+    onColorModeChange: (mode: 'light' | 'dark' | 'system') => void;
     binaryStatus: { found: boolean, message: string };
     onDownload: () => void;
     onSetPath: () => void;
@@ -14,7 +16,7 @@ interface HeaderProps {
     version: string;
 }
 
-export default function Header({ onThemeChange, currentTheme, binaryStatus, onDownload, onSetPath, onResetPath, isDownloading, downloadProgress, version }: HeaderProps) {
+export default function Header({ onThemeChange, currentTheme, colorMode, onColorModeChange, binaryStatus, onDownload, onSetPath, onResetPath, isDownloading, downloadProgress, version }: HeaderProps) {
     const { t, locale, setLocale, translations } = useI18n();
     const [showHelp, setShowHelp] = useState(false);
     const [showLangMenu, setShowLangMenu] = useState(false);
@@ -95,11 +97,38 @@ export default function Header({ onThemeChange, currentTheme, binaryStatus, onDo
                             <button
                                 key={th.id}
                                 onClick={() => onThemeChange(th.id)}
-                                className={`w-4 h-4 rounded-full transition-all hover:scale-125 active:scale-95 relative group/swatch ${currentTheme === th.id ? 'ring-2 ring-white ring-offset-2 ring-offset-black scale-110' : 'opacity-40 hover:opacity-100'}`}
-                                style={{ backgroundColor: th.color }}
+                                className={`w-4 h-4 rounded-full transition-all hover:scale-125 active:scale-95 relative group/swatch ${currentTheme === th.id ? 'ring-2 ring-white ring-offset-2 ring-offset-black scale-110' : 'opacity-50 hover:opacity-100'}`}
+                                style={{ backgroundColor: th.color, boxShadow: 'inset 0 0 0 1.5px var(--swatch-border)' }}
                             >
                                 <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 bg-zinc-900 border border-zinc-800 rounded text-[9px] font-bold uppercase tracking-widest text-white opacity-0 group-hover/swatch:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
                                     {th.label}
+                                </div>
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Color Mode Toggle */}
+                <div className="flex items-center gap-1 group/mode">
+                    <div className="flex items-center gap-0.5 p-0.5 rounded-lg border border-zinc-800 bg-zinc-900/60">
+                        {([
+                            { id: 'light' as const, Icon: Sun,     label: t('header.colorModes.light') },
+                            { id: 'dark'  as const, Icon: Moon,    label: t('header.colorModes.dark') },
+                            { id: 'system' as const, Icon: Monitor, label: t('header.colorModes.system') },
+                        ] as const).map(({ id, Icon, label }) => (
+                            <button
+                                key={id}
+                                onClick={() => onColorModeChange(id)}
+                                title={label}
+                                className={`relative p-1.5 rounded-md transition-all group/btn ${
+                                    colorMode === id
+                                        ? 'bg-primary text-on-primary shadow-sm'
+                                        : 'text-zinc-400 hover:text-primary hover:bg-zinc-800/60'
+                                }`}
+                            >
+                                <Icon size={11} />
+                                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 bg-zinc-900 border border-zinc-800 rounded text-[9px] font-bold uppercase tracking-widest text-white opacity-0 group-hover/btn:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
+                                    {label}
                                 </div>
                             </button>
                         ))}

--- a/src/components/LogPanel.tsx
+++ b/src/components/LogPanel.tsx
@@ -35,7 +35,7 @@ const LogPanel = memo(({ logs, onClear, onAddLog, onRunCommand }: LogPanelProps)
     };
 
     return (
-        <div className="glass rounded-2xl h-[220px] flex-none overflow-hidden font-mono border border-zinc-800 bg-black/60 backdrop-blur-xl flex flex-col shadow-2xl relative">
+        <div className="force-dark glass rounded-2xl h-[220px] flex-none overflow-hidden font-mono border border-zinc-800 bg-black/60 backdrop-blur-xl flex flex-col shadow-2xl relative">
             {/* Top Bar */}
             <div className="px-4 py-2.5 border-b border-zinc-800/80 bg-zinc-900/40 flex justify-between items-center shrink-0">
                 <div className="flex items-center gap-3">
@@ -75,7 +75,7 @@ const LogPanel = memo(({ logs, onClear, onAddLog, onRunCommand }: LogPanelProps)
                                 console.error("Export failed:", e);
                             }
                         }}
-                        className="flex items-center gap-1.5 text-[9px] font-black uppercase text-zinc-500 hover:text-primary transition-all px-2 py-1 rounded-md hover:bg-white/5 active:scale-95"
+                        className="flex items-center gap-1.5 text-[9px] font-black uppercase text-primary hover:text-primary/70 transition-all px-2 py-1 rounded-md hover:bg-white/5 active:scale-95"
                         title={t('logPanel.reportTitle')}
                     >
                         <Download size={10} />
@@ -83,7 +83,7 @@ const LogPanel = memo(({ logs, onClear, onAddLog, onRunCommand }: LogPanelProps)
                     </button>
                     <button
                         onClick={onClear}
-                        className="flex items-center gap-1.5 text-[9px] font-black uppercase text-zinc-500 hover:text-red-400 transition-all px-2 py-1 rounded-md hover:bg-white/5 active:scale-95"
+                        className="flex items-center gap-1.5 text-[9px] font-black uppercase text-primary hover:text-red-400 transition-all px-2 py-1 rounded-md hover:bg-white/5 active:scale-95"
                     >
                         <Trash2 size={10} />
                         {t('logPanel.clear')}
@@ -101,7 +101,7 @@ const LogPanel = memo(({ logs, onClear, onAddLog, onRunCommand }: LogPanelProps)
                     <div className="space-y-1">
                         {logs.map((log, i) => (
                             <div key={i} className="group flex gap-3 text-[11px] leading-relaxed py-0.5 border-l border-zinc-900 hover:border-primary/30 transition-colors pl-3">
-                                <span className="text-zinc-600 font-bold shrink-0 tabular-nums opacity-40 group-hover:opacity-100 transition-opacity">
+                                <span className="text-zinc-500 font-bold shrink-0 tabular-nums opacity-60 group-hover:opacity-100 transition-opacity">
                                     {new Date().toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })}
                                 </span>
                                 <span className="text-zinc-300 break-all selection:bg-primary/30 selection:text-on-primary">{log}</span>
@@ -120,7 +120,7 @@ const LogPanel = memo(({ logs, onClear, onAddLog, onRunCommand }: LogPanelProps)
                     onChange={(e) => setCommand(e.target.value)}
                     onKeyDown={handleKeyDown}
                     placeholder={t('logPanel.terminalPlaceholder')}
-                    className="flex-1 bg-transparent border-none outline-none text-[11px] text-zinc-300 placeholder:text-zinc-700 font-mono transition-colors focus:placeholder:text-zinc-800"
+                    className="flex-1 bg-transparent border-none outline-none text-[11px] text-zinc-300 placeholder:text-zinc-500 font-mono transition-colors focus:placeholder:text-zinc-600"
                 />
             </div>
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -51,12 +51,12 @@ export default function Sidebar({
     return (
         <aside className="lg:col-span-3 space-y-4">
             <div className="glass p-4 rounded-xl space-y-4 border border-zinc-800 bg-zinc-900/40 backdrop-blur-md">
-                <div className="flex justify-between items-center border-b border-zinc-800/50 pb-2 mb-1">
+                <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5 border-b border-zinc-800/50 pb-2 mb-1">
                     <h2 className="text-[11px] font-black uppercase tracking-widest flex items-center gap-2 text-zinc-400">
                         <Smartphone size={14} className="text-primary" />
                         {t('sidebar.deviceHub')}
                     </h2>
-                    <div className="flex gap-2 items-center">
+                    <div className="flex gap-2 items-center ml-auto">
                         <button
                             onClick={onKillAdb}
                             className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[9px] font-black uppercase tracking-tighter text-zinc-600 hover:text-red-400 hover:bg-red-500/5 transition-all group/zap"

--- a/src/hooks/useScrcpy.ts
+++ b/src/hooks/useScrcpy.ts
@@ -68,6 +68,13 @@ export function useScrcpy() {
     const [isOnboardingOpen, setIsOnboardingOpen] = useState(false);
     // Removed mdnsDevices state
     const [theme, setTheme] = useState("ultraviolet");
+    const [colorMode, setColorModeState] = useState<'light' | 'dark' | 'system'>(() => {
+        try {
+            return (localStorage.getItem('scrcpy_color_mode') as 'light' | 'dark' | 'system') || 'system';
+        } catch {
+            return 'system';
+        }
+    });
     const [config, setConfig] = useState<ScrcpyConfig>({
         device: "",
         sessionMode: "mirror",
@@ -153,6 +160,26 @@ export function useScrcpy() {
         localStorage.setItem('scrcpy_theme', theme);
         document.documentElement.setAttribute('data-theme', theme);
     }, [theme, isInitialized]);
+
+    useEffect(() => {
+        const applyMode = (dark: boolean) => {
+            document.documentElement.setAttribute('data-mode', dark ? 'dark' : 'light');
+        };
+        if (colorMode === 'system') {
+            const mq = window.matchMedia('(prefers-color-scheme: dark)');
+            applyMode(mq.matches);
+            const handler = (e: MediaQueryListEvent) => applyMode(e.matches);
+            mq.addEventListener('change', handler);
+            return () => mq.removeEventListener('change', handler);
+        } else {
+            applyMode(colorMode === 'dark');
+        }
+    }, [colorMode]);
+
+    const setColorMode = (mode: 'light' | 'dark' | 'system') => {
+        setColorModeState(mode);
+        localStorage.setItem('scrcpy_color_mode', mode);
+    };
 
     // Clear detected cameras when device changes
     useEffect(() => {
@@ -543,6 +570,8 @@ export function useScrcpy() {
         setConfig,
         theme,
         setTheme,
+        colorMode,
+        setColorMode,
         pushFile,
         installApk,
         historyDevices,

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -27,6 +27,11 @@ export const en = {
             emerald: 'Emerald',
             bloodmoon: 'Blood Moon'
         },
+        colorModes: {
+            light: 'Light',
+            dark: 'Dark',
+            system: 'System'
+        },
         languageLabel: 'Language',
         tagline: 'Mirror & Control Android // Devices Easily',
         scrcpyEngine: 'Scrcpy Engine',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -26,6 +26,11 @@ export const fr: Translations = {
             emerald: 'Émeraude',
             bloodmoon: 'Lune de Sang'
         },
+        colorModes: {
+            light: 'Clair',
+            dark: 'Sombre',
+            system: 'Système'
+        },
         languageLabel: 'Langue',
         tagline: 'Miroir & Contrôle Android // Appareils Facilement',
         scrcpyEngine: 'Moteur Scrcpy',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -26,6 +26,11 @@ export const ptBR: Translations = {
             emerald: 'Esmeralda',
             bloodmoon: 'Lua de Sangue'
         },
+        colorModes: {
+            light: 'Claro',
+            dark: 'Escuro',
+            system: 'Sistema'
+        },
         languageLabel: 'Idioma',
         tagline: 'Espelhar & Controlar Android // Dispositivos com Facilidade',
         scrcpyEngine: 'Motor Scrcpy',

--- a/src/index.css
+++ b/src/index.css
@@ -6,12 +6,30 @@
   --font-sans: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
 }
 
+/* ── Base variables (dark defaults) ─────────────────── */
 :root {
   --primary: #8b5cf6;
   --text-on-primary: #ffffff;
   --bg-base: #010101;
+
+  /* Semantic tokens */
+  --text-base: #e4e4e7;
+  --text-muted: #a1a1aa;
+  --text-subtle: #71717a;
+  --bg-surface: #18181b;
+  --bg-elevated: #09090b;
+  --bg-input: #27272a;
+  --border-base: #27272a;
+  --border-subtle: #3f3f46;
+  --glass-bg: rgba(24, 24, 27, 0.6);
+  --glass-border: rgba(255, 255, 255, 0.05);
+  --scrollbar-track: #09090b;
+  --scrollbar-thumb: #27272a;
+  --scrollbar-thumb-hover: #3f3f46;
+  --swatch-border: rgba(255, 255, 255, 0.15);
 }
 
+/* ── Color themes (dark) ────────────────────────────── */
 [data-theme='ultraviolet'] {
   --primary: #8b5cf6;
   --text-on-primary: #ffffff;
@@ -42,12 +60,51 @@
   --bg-base: #0a0404;
 }
 
+/* ── Light mode tokens (warm stone-based palette) ─── */
+[data-mode='light'] {
+  --text-base: #1c1917;        /* stone-900 - warm near-black */
+  --text-muted: #57534e;       /* stone-600 - readable medium */
+  --text-subtle: #78716c;      /* stone-500 */
+  --bg-surface: #fafaf9;       /* stone-50 - warm white */
+  --bg-elevated: #f5f5f4;      /* stone-100 */
+  --bg-input: #e7e5e4;         /* stone-200 */
+  --border-base: #d6d3d1;      /* stone-300 – visible but not harsh */
+  --border-subtle: #e7e5e4;    /* stone-200 */
+  --glass-bg: rgba(250, 250, 249, 0.78);
+  --glass-border: rgba(28, 25, 23, 0.12);
+  --scrollbar-track: transparent;
+  --scrollbar-thumb: #d6d3d1;
+  --scrollbar-thumb-hover: #a8a29e;
+  --swatch-border: rgba(28, 25, 23, 0.25);
+  color-scheme: light;
+}
+
+/* Per-theme light bg-base & primary adjustments */
+[data-theme='ultraviolet'][data-mode='light'] {
+  --bg-base: #f5f1ff;
+}
+[data-theme='astro'][data-mode='light'] {
+  --bg-base: #eef4ff;
+}
+[data-theme='carbon'][data-mode='light'] {
+  --bg-base: #f5f5f4;
+  --primary: #1c1917;          /* stone-900, warmer than pure black */
+  --text-on-primary: #fafaf9;
+}
+[data-theme='emerald'][data-mode='light'] {
+  --bg-base: #ecfdf5;
+}
+[data-theme='bloodmoon'][data-mode='light'] {
+  --bg-base: #fff1f2;
+}
+
+/* ── Base styles ────────────────────────────────────── */
 body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
   background-color: var(--bg-base);
-  color: #fff;
+  color: var(--text-base);
   transition: color 0.3s, background-color 0.5s ease;
 }
 
@@ -58,23 +115,23 @@ body {
 }
 
 ::-webkit-scrollbar-track {
-  background: #09090b;
+  background: var(--scrollbar-track);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #27272a;
+  background: var(--scrollbar-thumb);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #3f3f46;
+  background: var(--scrollbar-thumb-hover);
 }
 
 .glass {
-  background: rgba(24, 24, 27, 0.6);
+  background: var(--glass-bg);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--glass-border);
 }
 
 /* Custom Range Slider */
@@ -101,4 +158,108 @@ body {
   border-radius: 50%;
   cursor: grab;
   border: 2px solid #000;
+}
+
+[data-mode='light'] .custom-range::-webkit-slider-thumb { border-color: #fafaf9; }
+[data-mode='light'] .custom-range::-moz-range-thumb     { border-color: #fafaf9; }
+
+/* ── .force-dark: element stays dark regardless of mode ─── */
+/* Used on the terminal/log panel so it always looks like a dark terminal. */
+[data-mode='light'] .force-dark,
+[data-mode='light'] .force-dark.glass {
+  background-color: rgba(9, 9, 11, 0.94) !important;
+  border-color: rgba(255, 255, 255, 0.07) !important;
+}
+
+[data-mode='light'] .force-dark .text-white    { color: #ffffff     !important; }
+[data-mode='light'] .force-dark .text-zinc-200 { color: #e4e4e7     !important; }
+[data-mode='light'] .force-dark .text-zinc-300 { color: #d4d4d8     !important; }
+[data-mode='light'] .force-dark .text-zinc-400 { color: #a1a1aa     !important; }
+[data-mode='light'] .force-dark .text-zinc-500 { color: #71717a     !important; }
+[data-mode='light'] .force-dark .text-zinc-600 { color: #52525b     !important; }
+[data-mode='light'] .force-dark .text-zinc-700 { color: #3f3f46     !important; }
+
+[data-mode='light'] .force-dark .border-zinc-800       { border-color: #27272a                  !important; }
+[data-mode='light'] .force-dark .border-zinc-800\/80   { border-color: rgba(39,39,42,0.8)       !important; }
+[data-mode='light'] .force-dark .border-zinc-900       { border-color: #18181b                  !important; }
+
+[data-mode='light'] .force-dark .bg-black\/60          { background-color: rgba(0,0,0,0.92)     !important; }
+[data-mode='light'] .force-dark .bg-black\/40          { background-color: rgba(0,0,0,0.80)     !important; }
+[data-mode='light'] .force-dark .bg-zinc-900\/40       { background-color: rgba(24,24,27,0.90)  !important; }
+[data-mode='light'] .force-dark .bg-white\/5           { background-color: rgba(255,255,255,0.05) !important; }
+
+[data-mode='light'] .force-dark .placeholder\:text-zinc-500::placeholder       { color: #71717a !important; }
+[data-mode='light'] .force-dark .focus\:placeholder\:text-zinc-600:focus::placeholder { color: #52525b !important; }
+/* Outside @layer so they win over Tailwind utilities. Stone-based for warmth. */
+
+/* Solid backgrounds */
+[data-mode='light'] .bg-zinc-950 { background-color: var(--bg-elevated); }
+[data-mode='light'] .bg-zinc-900 { background-color: var(--bg-surface); }
+[data-mode='light'] .bg-zinc-800 { background-color: var(--bg-input); }
+[data-mode='light'] .bg-zinc-700 { background-color: #d6d3d1; }
+[data-mode='light'] .bg-black    { background-color: #1c1917; }
+[data-mode='light'] .bg-white    { background-color: #1c1917; }
+
+/* Translucent backgrounds (zinc-950 → light surface w/ matching opacity feel) */
+[data-mode='light'] .bg-zinc-950\/20 { background-color: rgb(245 245 244 / 60%); }
+[data-mode='light'] .bg-zinc-950\/30 { background-color: rgb(245 245 244 / 70%); }
+[data-mode='light'] .bg-zinc-950\/40 { background-color: rgb(250 250 249 / 75%); }
+[data-mode='light'] .bg-zinc-950\/50 { background-color: rgb(255 255 255 / 80%); }
+[data-mode='light'] .bg-zinc-950\/60 { background-color: rgb(255 255 255 / 85%); }
+[data-mode='light'] .bg-zinc-950\/90 { background-color: rgb(255 255 255 / 92%); }
+[data-mode='light'] .bg-zinc-950\/95 { background-color: rgb(255 255 255 / 95%); }
+
+[data-mode='light'] .bg-zinc-900\/40 { background-color: rgb(245 245 244 / 60%); }
+[data-mode='light'] .bg-zinc-900\/50 { background-color: rgb(245 245 244 / 70%); }
+[data-mode='light'] .bg-zinc-900\/60 { background-color: rgb(255 255 255 / 70%); }
+[data-mode='light'] .bg-zinc-900\/80 { background-color: rgb(255 255 255 / 85%); }
+[data-mode='light'] .bg-zinc-900\/95 { background-color: rgb(255 255 255 / 95%); }
+
+[data-mode='light'] .bg-zinc-800\/20 { background-color: rgb(231 229 228 / 35%); }
+[data-mode='light'] .bg-zinc-800\/30 { background-color: rgb(231 229 228 / 50%); }
+[data-mode='light'] .bg-zinc-800\/50 { background-color: rgb(231 229 228 / 70%); }
+[data-mode='light'] .bg-zinc-800\/60 { background-color: rgb(231 229 228 / 80%); }
+
+[data-mode='light'] .bg-black\/20 { background-color: rgb(0 0 0 / 3%); }
+[data-mode='light'] .bg-black\/40 { background-color: rgb(0 0 0 / 6%); }
+[data-mode='light'] .bg-black\/60 { background-color: rgb(0 0 0 / 38%); }
+[data-mode='light'] .bg-black\/80 { background-color: rgb(0 0 0 / 55%); }
+
+[data-mode='light'] .bg-white\/5 { background-color: rgb(28 25 23 / 6%); }
+
+/* Text */
+[data-mode='light'] .text-white    { color: var(--text-base); }
+[data-mode='light'] .text-zinc-200 { color: var(--text-base); }
+[data-mode='light'] .text-zinc-300 { color: #292524; }
+[data-mode='light'] .text-zinc-400 { color: #44403c; }
+[data-mode='light'] .text-zinc-500 { color: #57534e; }
+[data-mode='light'] .text-zinc-600 { color: #78716c; }
+[data-mode='light'] .text-zinc-700 { color: #a8a29e; }
+[data-mode='light'] .text-zinc-800 { color: #d6d3d1; }
+[data-mode='light'] .text-black    { color: #fafaf9; }
+
+/* Hover text overrides */
+[data-mode='light'] .hover\:text-white:hover { color: var(--text-base); }
+
+/* Borders – stone-300 base keeps cards defined without harsh column artifacts */
+[data-mode='light'] .border-zinc-800     { border-color: var(--border-base); }        /* stone-300 */
+[data-mode='light'] .border-zinc-800\/50 { border-color: rgb(214 211 209 / 20%); }    /* very subtle */
+[data-mode='light'] .border-zinc-800\/60 { border-color: rgb(214 211 209 / 30%); }
+[data-mode='light'] .border-zinc-800\/80 { border-color: rgb(214 211 209 / 50%); }
+[data-mode='light'] .border-zinc-700     { border-color: #e7e5e4; }
+[data-mode='light'] .border-zinc-700\/30 { border-color: rgb(231 229 228 / 40%); }
+[data-mode='light'] .border-zinc-900     { border-color: #78716c; }
+[data-mode='light'] .border-zinc-500     { border-color: #57534e; }
+[data-mode='light'] .border-white\/5     { border-color: rgb(28 25 23 / 10%); }
+
+/* Theme swatch: ring colors and offset adapt to mode (used in Header) */
+[data-mode='light'] .ring-white        { --tw-ring-color: #1c1917; }
+[data-mode='light'] .ring-offset-black { --tw-ring-offset-color: var(--bg-base); }
+
+/* In light mode, the warm-stone bg is opaque enough; backdrop-filter only
+   adds an edge shimmer at the rounded card boundary that reads as a stray
+   vertical line. Force-dark panels (terminal) keep their own !important bg. */
+[data-mode='light'] .glass {
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }


### PR DESCRIPTION
## Summary

This PR adds light mode support and a system color mode option to the app.

Closes #60.
Related to #22.

It includes:
- A new light color mode
- A dark color mode
- A system mode that follows the browser/OS `prefers-color-scheme` setting
- Persistence of the selected color mode using `localStorage`
- Updated theme variables for light mode
- Header controls to switch between Light, Dark, and System modes

## Implementation notes

The default color mode is `system`, so the app follows the user's OS/browser preference on first launch.

When `system` mode is selected, the app listens to `prefers-color-scheme` changes and updates the UI accordingly.

The selected color mode is stored separately from the existing visual theme, using its own `localStorage` key.

This should address the light mode request from #60. It is also related to #22 because the light/dark mode work updates UI colors and improves theme visibility, although #22 may still need further icon-specific adjustments if desired.

## Testing

Tested locally on Windows using:

```bash
npm run lint
npm test
npm run tauri build -- --no-bundle
npm run tauri dev
```

I verified that:
- the app starts correctly
- TypeScript checks pass
- all tests pass
- the Tauri release build succeeds without bundling
- light mode can be selected manually
- dark mode can be selected manually
- system mode follows the Windows light/dark setting
- the selected color mode persists after reloading the app
- the existing i18n language selector still works correctly

<img width="2104" height="1612" alt="image" src="https://github.com/user-attachments/assets/68b113b9-7107-45f0-bc18-87d8cd0a0e7d" />
