### PR TITLE
feat: implement wireless device auto-detection and connection via mDNS

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3208,7 +3208,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrcpy-gui-v3"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "chrono",
  "flate2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ function App() {
     clearLogs,
     detectedCameras,
     renderDriverSupport,
+    mdnsDevices,
     config,
     setConfig,
     theme,
@@ -332,6 +333,7 @@ function App() {
                     onFilePush={handleFileBrowse}
                     historyDevices={historyDevices}
                     clearHistory={clearHistory}
+                    mdnsDevices={mdnsDevices}
                   />
                 </div>
               </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Smartphone, RefreshCw, Usb, Wifi, UploadCloud, Zap } from 'lucide-react';
 import { useI18n } from '../i18n';
+import { MdnsDevice } from '../hooks/useScrcpy';
 
 export interface SidebarProps {
     devices: string[];
@@ -18,6 +19,7 @@ export interface SidebarProps {
     // History props
     historyDevices?: string[];
     clearHistory?: () => void;
+    mdnsDevices?: MdnsDevice[];
 }
 
 export default function Sidebar({
@@ -34,7 +36,8 @@ export default function Sidebar({
     isRefreshing,
     onFilePush,
     historyDevices = [],
-    clearHistory = () => { }
+    clearHistory = () => { },
+    mdnsDevices = []
 }: SidebarProps) {
     const { t } = useI18n();
     const [activeTab, setActiveTab] = React.useState<'usb' | 'wireless'>('usb');
@@ -195,6 +198,40 @@ export default function Sidebar({
                                 </div>
 
                             </div>
+
+                            {/* Discovered Devices (mDNS) */}
+                            {mdnsDevices && mdnsDevices.filter(dev => !devices.includes(dev.address)).length > 0 && (
+                                <div className="space-y-3 pt-1">
+                                    <div className="flex items-center justify-between border-b border-zinc-800/50 pb-1.5">
+                                        <span className="text-[9px] font-black uppercase text-primary/60 tracking-widest">{t('sidebar.discoveredDevices')}</span>
+                                    </div>
+                                    <div className="space-y-2">
+                                        {mdnsDevices
+                                            .filter(dev => !devices.includes(dev.address))
+                                            .map((dev, idx) => (
+                                                <button
+                                                    key={idx}
+                                                    disabled={isRefreshing}
+                                                    onClick={() => {
+                                                        setConnectIp(dev.address);
+                                                        handleConnect(dev.address);
+                                                    }}
+                                                    className="w-full flex items-center justify-between p-2 rounded-lg bg-zinc-800/20 border border-zinc-800/50 hover:bg-zinc-800/50 hover:border-zinc-700 transition-all group text-left"
+                                                >
+                                                    <div className="flex items-center gap-2 min-w-0">
+                                                        <Wifi size={10} className="text-zinc-500 group-hover:text-zinc-300 shrink-0" />
+                                                        <span className="text-[10px] font-bold text-zinc-400 group-hover:text-zinc-200 truncate" title={`${dev.name} (${dev.address})`}>
+                                                            {dev.name} ({dev.address})
+                                                        </span>
+                                                    </div>
+                                                    <div className="text-[8px] text-primary opacity-0 group-hover:opacity-100 uppercase font-black tracking-tighter shrink-0 ml-2">
+                                                        {t('sidebar.connect')}
+                                                    </div>
+                                                </button>
+                                            ))}
+                                    </div>
+                                </div>
+                            )}
 
                             {/* Recent Devices History */}
                             {historyDevices.length > 0 && (

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -54,4 +54,26 @@ describe('Sidebar Component', () => {
         fireEvent.click(screen.getByText('Wireless'));
         expect(screen.getByText('Wireless Setup Tip')).toBeInTheDocument();
     });
+
+    it('renders mdns discovered devices and calls onConnect when clicked', () => {
+        const mdnsProps = {
+            ...mockProps,
+            mdnsDevices: [
+                { name: 'DiscoveredPhone', service: '_adb-tls-connect._tcp', address: '192.168.0.104:44321' }
+            ]
+        };
+        render(<Sidebar {...mdnsProps} />);
+
+        // Switch to Wireless tab to see it
+        fireEvent.click(screen.getByText('Wireless'));
+        expect(screen.getByText(/DiscoveredPhone/)).toBeInTheDocument();
+
+        // Click the connect button next to/on the discovered device
+        const connectBtn = screen.getByText(/DiscoveredPhone/).closest('button');
+        expect(connectBtn).toBeInTheDocument();
+        if (connectBtn) {
+            fireEvent.click(connectBtn);
+            expect(mockProps.onConnect).toHaveBeenCalledWith('192.168.0.104:44321');
+        }
+    });
 });

--- a/src/hooks/useScrcpy.ts
+++ b/src/hooks/useScrcpy.ts
@@ -14,6 +14,12 @@ export interface RenderDriverSupport {
     supportedDrivers: RenderDriverOption[];
 }
 
+export interface MdnsDevice {
+    name: string;
+    service: string;
+    address: string;
+}
+
 export interface ScrcpyConfig {
     device: string;
     sessionMode: string;
@@ -73,7 +79,8 @@ export function useScrcpy() {
     });
     const [isRefreshing, setIsRefreshing] = useState(false);
     const [isOnboardingOpen, setIsOnboardingOpen] = useState(false);
-    // Removed mdnsDevices state
+    const [mdnsDevices, setMdnsDevices] = useState<MdnsDevice[]>([]);
+    const attemptedConnectionsRef = useRef<Set<string>>(new Set());
     const [theme, setTheme] = useState("ultraviolet");
     const [colorMode, setColorModeState] = useState<'light' | 'dark' | 'system'>(() => {
         try {
@@ -273,11 +280,17 @@ export function useScrcpy() {
     const refreshDevices = async (customPath?: string, silent: boolean = false) => {
         if (isRefreshing) return;
         setIsRefreshing(true);
+
+        if (!silent) {
+            attemptedConnectionsRef.current.clear();
+        }
+
         try {
             const res: any = await invoke('get_devices', { customPath: customPath || config.scrcpyPath });
+            let newDevices: string[] = [];
 
             if (!res.error) {
-                const newDevices = res.devices as string[];
+                newDevices = res.devices as string[];
                 const prevDevices = prevDevicesRef.current;
 
                 // Identify connections/disconnections
@@ -304,6 +317,46 @@ export function useScrcpy() {
                 }
             } else {
                 setLogs(prev => [...prev.slice(-100), t('logs.discoveryError', { error: res.error })]);
+            }
+
+            // Fetch wireless devices broadcasting on the network via mDNS
+            try {
+                const mdnsRes: any = await invoke('get_mdns_devices', { customPath: customPath || config.scrcpyPath });
+                if (mdnsRes && !mdnsRes.error && mdnsRes.services) {
+                    const parsedMdns = (mdnsRes.services as any[]).filter(s => s.service && s.service.includes('_adb-tls-connect'));
+                    setMdnsDevices(parsedMdns);
+
+                    // Auto-connect to discovered but unconnected devices if option is enabled
+                    if (isAutoConnect) {
+                        for (const dev of parsedMdns) {
+                            const addr = dev.address;
+                            if (!newDevices.includes(addr) && !attemptedConnectionsRef.current.has(addr)) {
+                                attemptedConnectionsRef.current.add(addr);
+                                setLogs(prev => [...prev.slice(-100), `[Auto-Connect] Discovered wireless device at ${addr}, connecting...`]);
+
+                                invoke('adb_connect', { ip: addr, customPath: customPath || config.scrcpyPath })
+                                    .then((connectRes: any) => {
+                                        if (connectRes && connectRes.success) {
+                                            setLogs(prev => [...prev.slice(-100), `[Auto-Connect] Successfully connected to ${addr}`]);
+                                            setTimeout(() => {
+                                                refreshDevices(customPath || config.scrcpyPath, true);
+                                            }, 1000);
+                                        } else {
+                                            setLogs(prev => [...prev.slice(-100), `[Auto-Connect] Failed to connect to ${addr}: ${connectRes?.message || 'unknown error'}`]);
+                                        }
+                                    })
+                                    .catch(err => {
+                                        setLogs(prev => [...prev.slice(-100), `[Auto-Connect] Error connecting to ${addr}: ${String(err)}`]);
+                                    });
+                            }
+                        }
+                    }
+                } else if (mdnsRes && mdnsRes.error) {
+                    console.warn("[ADB MDNS] Failed to get mdns devices:", mdnsRes.message);
+                    setMdnsDevices([]);
+                }
+            } catch (mdnsErr) {
+                console.error("Failed to query mDNS devices:", mdnsErr);
             }
         } catch (e) {
             console.error(e);
@@ -580,6 +633,7 @@ export function useScrcpy() {
         detectedCameras,
         renderDriverSupport,
         isRefreshing,
+        mdnsDevices,
         config,
         setConfig,
         theme,

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -87,6 +87,7 @@ export const en = {
         connect: 'Connect',
         connecting: '...',
         recentDevices: 'Recent Devices',
+        discoveredDevices: 'Discovered Devices (mDNS)',
         clear: 'Clear',
         pairDeviceTitle: '2. Pair Device (Android 11+)',
         ipPortPlaceholder: 'IP:Port',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -85,6 +85,7 @@ export const fr: Translations = {
         connect: 'Connecter',
         connecting: '...',
         recentDevices: 'Appareils Récents',
+        discoveredDevices: 'Appareils Découverts (mDNS)',
         clear: 'Effacer',
         pairDeviceTitle: '2. Appairer l\'Appareil (Android 11+)',
         ipPortPlaceholder: 'IP:Port',

--- a/src/i18n/locales/id.ts
+++ b/src/i18n/locales/id.ts
@@ -89,6 +89,7 @@ export const id: Translations = {
         connect: 'Sambungkan',
         connecting: '...',
         recentDevices: 'Perangkat Terbaru',
+        discoveredDevices: 'Perangkat Ditemukan (mDNS)',
         clear: 'Hapus',
         pairDeviceTitle: '2. Pairing Perangkat (Android 11+)',
         ipPortPlaceholder: 'IP:Port',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -85,6 +85,7 @@ export const ptBR: Translations = {
         connect: 'Conectar',
         connecting: '...',
         recentDevices: 'Dispositivos Recentes',
+        discoveredDevices: 'Dispositivos Descobertos (mDNS)',
         clear: 'Limpar',
         pairDeviceTitle: '2. Parear Dispositivo (Android 11+)',
         ipPortPlaceholder: 'IP:Porta',

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -93,6 +93,7 @@ export const ru: Translations = {
     connect: 'Подключить',
     connecting: '...',
     recentDevices: 'Недавние устройства',
+    discoveredDevices: 'Обнаруженные устройства (mDNS)',
     clear: 'Очистить',
     pairDeviceTitle: '2. Сопряжение устройства (Android 11+)',
     ipPortPlaceholder: 'IP:Порт',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -89,6 +89,7 @@ export const zhCN: Translations = {
         connect: '连接',
         connecting: '连接中...',
         recentDevices: '最近设备',
+        discoveredDevices: '已发现的设备 (mDNS)',
         clear: '清除',
         pairDeviceTitle: '2. 配对设备 (Android 11+)',
         ipPortPlaceholder: 'IP:端口',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -85,6 +85,7 @@ export const zhTW: Translations = {
         connect: '連線',
         connecting: '連線中...',
         recentDevices: '最近裝置',
+        discoveredDevices: '已偵測的裝置 (mDNS)',
         clear: '清除',
         pairDeviceTitle: '2. 配對裝置 (Android 11+)',
         ipPortPlaceholder: 'IP:Port',


### PR DESCRIPTION
This PR implements automatic wireless debugging device detection and connection using ADB mDNS services. It directly resolves the issue where wireless debugging cannot connect automatically due to a hardcoded/stale port. Closes #58.