### PR TITLE
✨Feat: remember/restore mirror window position, drag & recentre shortcuts for borderless windows

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3221,6 +3221,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-shell",
  "tokio",
+ "windows",
  "zip",
 ]
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -844,7 +844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1169,6 +1169,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,6 +1311,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -2413,7 +2441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3113,7 +3141,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3219,6 +3247,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-shell",
  "tokio",
  "windows",
@@ -3569,7 +3598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3987,6 +4016,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9f4c5136c09cd962da0c86dc4accd4666db2ea591cf16e6597435843bd2b"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4117,7 +4161,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4925,7 +4969,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5528,6 +5572,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5536,6 +5597,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,3 +30,13 @@ tauri-plugin-shell = "2.3.5"
 tauri-plugin-dialog = "2.7.0"
 chrono = "0.4.43"
 
+# Windows-only: read the scrcpy mirror window's client-area position natively
+# (EnumWindows + ClientToScreen) to persist it across sessions. Pinned to the
+# 0.61 line already resolved transitively by tao/wry, so Cargo unifies onto a
+# single compiled copy (no duplicate `windows` version).
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Graphics_Gdi",
+] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,4 +39,8 @@ windows = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
     "Win32_Graphics_Gdi",
+    "Win32_System_LibraryLoader",
 ] }
+# Windows-only: global shortcut (Ctrl+Alt+M) to drag the borderless scrcpy
+# window with the mouse. See src/grab.rs.
+tauri-plugin-global-shortcut = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,10 @@ tokio = { version = "1.49.0", features = ["full"] }
 tauri-plugin-shell = "2.3.5"
 tauri-plugin-dialog = "2.7.0"
 chrono = "0.4.43"
+# Global OS shortcuts: Ctrl+Alt+Shift+C to recentre the active mirror window
+# (all platforms) and Ctrl+Alt+Shift+W to drag the borderless scrcpy window
+# with the mouse (Windows-only). See src/shortcuts.rs and src/grab.rs.
+tauri-plugin-global-shortcut = "2"
 
 # Windows-only: read the scrcpy mirror window's client-area position natively
 # (EnumWindows + ClientToScreen) to persist it across sessions. Pinned to the
@@ -41,6 +45,3 @@ windows = { version = "0.61", features = [
     "Win32_Graphics_Gdi",
     "Win32_System_LibraryLoader",
 ] }
-# Windows-only: global shortcut (Ctrl+Alt+M) to drag the borderless scrcpy
-# window with the mouse. See src/grab.rs.
-tauri-plugin-global-shortcut = "2"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -722,6 +722,12 @@ pub struct ScrcpyConfig {
     /// Force SDL renderer VSync on/off (anti-tearing). scrcpy 4.0 (SDL3)
     /// disables renderer VSync by default; this re-asserts it via the SDL hint.
     vsync: Option<bool>,
+    /// Last known screen position of the scrcpy mirror window. Captured (client
+    /// area top-left) while a windowed session runs and restored via
+    /// --window-x / --window-y on the next launch, so the window reopens where
+    /// the user left it, including when relaunching borderless.
+    window_x: Option<i32>,
+    window_y: Option<i32>,
 }
 
 fn resolve_audio_codec_flag<'a>(config: &'a ScrcpyConfig, audio_codec_override: Option<&'a str>) -> Option<&'a str> {
@@ -739,6 +745,189 @@ fn resolve_audio_codec_flag<'a>(config: &'a ScrcpyConfig, audio_codec_override: 
             Some(trimmed)
         }
     })
+}
+
+/// Parses `KEY=value` shell output (as printed by `xdotool ... --shell`) and
+/// returns the integer value for `key`. Only compiled where it is used (the
+/// Linux capture path, and the unit tests).
+#[cfg(any(test, target_os = "linux"))]
+fn parse_shell_var_int(text: &str, key: &str) -> Option<i32> {
+    let prefix = format!("{}=", key);
+    text.lines()
+        .find(|l| l.starts_with(&prefix))
+        .and_then(|l| l[prefix.len()..].trim().parse().ok())
+}
+
+/// Queries the on-screen position of the scrcpy SDL window owned by process
+/// `pid`, returning the client-area top-left in screen pixels. Returns `None`
+/// silently whenever the window can't be read (not created yet, minimized,
+/// tooling missing, permission denied); every failure mode is non-fatal.
+///
+/// The reference frame differs per platform and is reconciled afterwards by
+/// [`resolve_window_pos_to_persist`], rather than by hardcoding decoration
+/// sizes:
+/// - Windows: Win32 `ClientToScreen` -> client origin (matches scrcpy/SDL).
+/// - Linux/X11 (+XWayland): `xdotool` -> window origin (usually the client area).
+/// - macOS: `osascript`/System Events -> frame origin (title-bar top).
+fn try_capture_window_pos(pid: u32) -> Option<(i32, i32)> {
+    #[cfg(target_os = "windows")]
+    {
+        // Native Win32: find this PID's main window and read its client-area
+        // origin. This replaces spawning PowerShell + `Add-Type` (a C# JIT) on
+        // every poll, it is a couple of direct syscalls with no child process.
+        use windows::core::BOOL;
+        use windows::Win32::Foundation::{HWND, LPARAM, POINT};
+        use windows::Win32::Graphics::Gdi::ClientToScreen;
+        use windows::Win32::UI::WindowsAndMessaging::{
+            EnumWindows, GetWindow, GetWindowThreadProcessId, IsIconic, IsWindowVisible, IsZoomed,
+            GW_OWNER,
+        };
+
+        // State threaded through EnumWindows via LPARAM.
+        struct Search {
+            target_pid: u32,
+            found: HWND,
+        }
+
+        // WNDENUMPROC: BOOL(1) keeps enumerating, BOOL(0) stops.
+        unsafe extern "system" fn enum_proc(hwnd: HWND, lparam: LPARAM) -> BOOL {
+            let search = &mut *(lparam.0 as *mut Search);
+            // Match .NET's MainWindowHandle heuristic: the first visible, unowned
+            // top-level window of the process, i.e. scrcpy's SDL mirror window,
+            // not an owned tool/popup window.
+            if !IsWindowVisible(hwnd).as_bool() {
+                return BOOL(1);
+            }
+            if GetWindow(hwnd, GW_OWNER).map(|o| !o.0.is_null()).unwrap_or(false) {
+                return BOOL(1);
+            }
+            let mut wnd_pid: u32 = 0;
+            let _ = GetWindowThreadProcessId(hwnd, Some(&mut wnd_pid as *mut u32));
+            if wnd_pid == search.target_pid {
+                search.found = hwnd;
+                return BOOL(0); // found it -> stop enumeration
+            }
+            BOOL(1)
+        }
+
+        let mut search = Search {
+            target_pid: pid,
+            found: HWND::default(),
+        };
+        // EnumWindows returns Err both on real failure and when the callback
+        // returns BOOL(0) (our intentional early stop), so ignore the Result
+        // and read the captured handle instead.
+        unsafe {
+            let _ = EnumWindows(Some(enum_proc), LPARAM(&mut search as *mut Search as isize));
+        }
+        let hwnd = search.found;
+        if !hwnd.0.is_null() {
+            // A minimized window reports an off-screen sentinel origin
+            // (~ -32000,-32000) and a maximized one the monitor edge; neither is
+            // the windowed position we want, so skip them and keep the last good
+            // sample.
+            let special = unsafe { IsIconic(hwnd).as_bool() || IsZoomed(hwnd).as_bool() };
+            if !special {
+                // ClientToScreen maps the client-area origin (0,0) into screen
+                // pixels; GetWindowRect would return the outer frame and creep
+                // the window up by the title-bar height on every relaunch.
+                let mut pt = POINT { x: 0, y: 0 };
+                if unsafe { ClientToScreen(hwnd, &mut pt) }.as_bool() {
+                    return Some((pt.x, pt.y));
+                }
+            }
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let pid_str = pid.to_string();
+        let output = StdCommand::new("xdotool")
+            .args(["search", "--pid", &pid_str, "getwindowgeometry", "--shell"])
+            .output()
+            .ok()?;
+        if output.status.success() {
+            let text = String::from_utf8_lossy(&output.stdout);
+            let x = parse_shell_var_int(&text, "X")?;
+            let y = parse_shell_var_int(&text, "Y")?;
+            return Some((x, y));
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // System Events needs Accessibility permission for the app (one-time
+        // grant in System Settings). The try block swallows every error (no
+        // window yet, permission denied, ...) so this stays a silent no-op
+        // until the permission is granted.
+        let script = format!(
+            concat!(
+                "tell application \"System Events\"\n",
+                "try\n",
+                "set proc to first process whose unix id is {}\n",
+                "set pos to position of first window of proc\n",
+                "((item 1 of pos) as string) & \" \" & ((item 2 of pos) as string)\n",
+                "end try\n",
+                "end tell"
+            ),
+            pid
+        );
+        let output = StdCommand::new("osascript")
+            .args(["-e", &script])
+            .output()
+            .ok()?;
+        if output.status.success() {
+            let text = String::from_utf8_lossy(&output.stdout);
+            let mut parts = text.split_whitespace();
+            let x: i32 = parts.next()?.parse().ok()?;
+            let y: i32 = parts.next()?.parse().ok()?;
+            return Some((x, y));
+        }
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+    let _ = pid;
+    None
+}
+
+/// Converts a raw captured position into the value to persist as
+/// --window-x/--window-y so the window round-trips exactly on the next launch.
+///
+/// [`try_capture_window_pos`] reports coordinates in each OS tool's native
+/// frame, which may differ from scrcpy's own (SDL) reference by the window
+/// decorations, a difference that varies by platform, window manager, theme
+/// and SDL version. Instead of hardcoding decoration sizes we learn the offset
+/// live: when we launched at an explicit position (`requested`), the delta
+/// between it and the *first* sample (`first`, taken before the user can move
+/// the window) is the decoration offset; subtracting it from the last sample
+/// yields a value that round-trips. Offsets larger than any plausible window
+/// decoration are ignored (the window was moved before the first sample, or was
+/// placed by the WM), falling back to the raw `last` position.
+fn resolve_window_pos_to_persist(
+    requested: Option<(i32, i32)>,
+    first: Option<(i32, i32)>,
+    last: (i32, i32),
+) -> (i32, i32) {
+    if let (Some((rx, ry)), Some((fx, fy))) = (requested, first) {
+        let (dx, dy) = (fx - rx, fy - ry);
+        if dx.abs() <= 80 && dy.abs() <= 120 {
+            return (last.0 - dx, last.1 - dy);
+        }
+    }
+    last
+}
+
+/// Emits the resolved window position (when one was captured) followed by the
+/// session-stopped status. Shared by every monitor-loop exit path.
+fn emit_window_pos_and_stop(
+    window: &Window,
+    device: &str,
+    requested: Option<(i32, i32)>,
+    first: Option<(i32, i32)>,
+    last: Option<(i32, i32)>,
+) {
+    if let Some(last) = last {
+        let (x, y) = resolve_window_pos_to_persist(requested, first, last);
+        let _ = window.emit("scrcpy-window-pos", json!({ "device": device, "x": x, "y": y }));
+    }
+    let _ = window.emit("scrcpy-status", json!({ "device": device, "running": false }));
 }
 
 fn build_scrcpy_args(config: &ScrcpyConfig, video_dir_fallback: Option<String>, audio_codec_override: Option<&str>) -> Vec<String> {
@@ -797,6 +986,19 @@ fn build_scrcpy_args(config: &ScrcpyConfig, video_dir_fallback: Option<String>, 
         if let Some(aot) = config.always_on_top { if aot { args.push("--always-on-top".to_string()); } }
         if let Some(fs) = config.fullscreen { if fs { args.push("--fullscreen".to_string()); } }
         if let Some(bl) = config.borderless { if bl { args.push("--window-borderless".to_string()); } }
+
+        // Restore the last saved window position (client-area origin), for
+        // mirror sessions only. Skipped in fullscreen (scrcpy ignores it) and
+        // for camera/desktop, whose windows must not share, or overwrite, the
+        // mirror window's remembered position.
+        if config.session_mode == "mirror" && !config.fullscreen.unwrap_or(false) {
+            if let Some(wx) = config.window_x {
+                args.push(format!("--window-x={}", wx));
+            }
+            if let Some(wy) = config.window_y {
+                args.push(format!("--window-y={}", wy));
+            }
+        }
         
         if let Some(rot) = &config.rotation {
             if rot != "0" {
@@ -1077,6 +1279,7 @@ pub async fn run_scrcpy(window: Window, state: State<'_, ScrcpyState>, config: S
         config.vsync.unwrap_or(true),
     ).await?;
 
+    let initial_scrcpy_pid = child.id();
     state.processes.lock().unwrap().insert(config.device.clone(), child);
     let _ = window.emit("scrcpy-status", json!({ "device": config.device, "running": true }));
 
@@ -1090,12 +1293,48 @@ pub async fn run_scrcpy(window: Window, state: State<'_, ScrcpyState>, config: S
     let server_path_mon = server_path;
     let config_mon = config.clone();
 
+    // Position we asked scrcpy to open at this launch (if any). Used to learn
+    // the decoration offset so the saved position round-trips exactly. See
+    // resolve_window_pos_to_persist.
+    let requested_pos: Option<(i32, i32)> = match (config_mon.window_x, config_mon.window_y) {
+        (Some(x), Some(y)) => Some((x, y)),
+        _ => None,
+    };
+    // Only track and persist the position for windowed mirror sessions. A
+    // fullscreen session has no meaningful position (it would report the
+    // monitor origin, e.g. 0,0), and camera/desktop sessions must not overwrite
+    // the mirror window's remembered position.
+    let track_pos = config_mon.session_mode == "mirror" && !config_mon.fullscreen.unwrap_or(false);
+
     tokio::spawn(async move {
         let mut current_audio_flag = audio_error_flag;
         let mut chain_index: usize = 0;
+        let mut current_scrcpy_pid = initial_scrcpy_pid;
+        let mut first_window_pos: Option<(i32, i32)> = None;
+        let mut last_window_pos: Option<(i32, i32)> = None;
 
         loop {
             tokio::time::sleep(Duration::from_millis(500)).await;
+
+            // Sample the live window position on every tick. This is the only
+            // path that can catch a move made right before the user closes the
+            // mirror window itself (rather than through stop_scrcpy, which
+            // grabs its own guaranteed-fresh sample): SDL destroys the window
+            // before the process exits, so by the time that exit is detected
+            // below the position is unreadable, and this periodic sample is
+            // all that is left to persist. Sampling every tick instead of
+            // every few seconds keeps that worst case down to ~500ms stale
+            // instead of several seconds.
+            if track_pos {
+                if let Some(pid) = current_scrcpy_pid {
+                    if let Some(pos) = try_capture_window_pos(pid) {
+                        if first_window_pos.is_none() {
+                            first_window_pos = Some(pos);
+                        }
+                        last_window_pos = Some(pos);
+                    }
+                }
+            }
 
             let outcome = {
                 let state_mon = app_handle_mon.state::<ScrcpyState>();
@@ -1124,11 +1363,22 @@ pub async fn run_scrcpy(window: Window, state: State<'_, ScrcpyState>, config: S
             match outcome {
                 AttemptOutcome::WaitError(e) => {
                     let _ = window_mon.emit("scrcpy-log", format!("[SYSTEM] Error waiting for scrcpy: {}", e));
-                    let _ = window_mon.emit("scrcpy-status", json!({ "device": device_mon, "running": false }));
+                    emit_window_pos_and_stop(&window_mon, &device_mon, requested_pos, first_window_pos, last_window_pos);
                     break;
                 }
                 AttemptOutcome::UserStopped => {
-                    let _ = window_mon.emit("scrcpy-status", json!({ "device": device_mon, "running": false }));
+                    // stop_scrcpy grabs one last, guaranteed-fresh sample right
+                    // before killing the process -- prefer it over our own
+                    // periodic sample, which can be up to ~3s stale if the
+                    // window was moved and closed in the same breath.
+                    let fresh_pos = app_handle_mon
+                        .state::<ScrcpyState>()
+                        .final_capture_hint
+                        .lock()
+                        .unwrap()
+                        .remove(&device_mon);
+                    let pos_to_persist = fresh_pos.or(last_window_pos);
+                    emit_window_pos_and_stop(&window_mon, &device_mon, requested_pos, first_window_pos, pos_to_persist);
                     break;
                 }
                 AttemptOutcome::Exited(status) => {
@@ -1158,6 +1408,15 @@ pub async fn run_scrcpy(window: Window, state: State<'_, ScrcpyState>, config: S
                             config_mon.vsync.unwrap_or(true),
                         ).await {
                             Ok((new_child, new_flag)) => {
+                                current_scrcpy_pid = new_child.id();
+                                // New window: re-learn its decoration offset by
+                                // resampling this attempt from scratch. Clear the
+                                // last sample too, so we never persist the old
+                                // window's position with the new (unlearned)
+                                // offset if this attempt closes before its first
+                                // sample.
+                                first_window_pos = None;
+                                last_window_pos = None;
                                 let state_mon = app_handle_mon.state::<ScrcpyState>();
                                 state_mon.processes.lock().unwrap().insert(device_mon.clone(), new_child);
                                 current_audio_flag = new_flag;
@@ -1166,7 +1425,7 @@ pub async fn run_scrcpy(window: Window, state: State<'_, ScrcpyState>, config: S
                             }
                             Err(e) => {
                                 let _ = window_mon.emit("scrcpy-log", format!("[SYSTEM] Failed to spawn retry: {}", e));
-                                let _ = window_mon.emit("scrcpy-status", json!({ "device": device_mon, "running": false }));
+                                emit_window_pos_and_stop(&window_mon, &device_mon, requested_pos, first_window_pos, last_window_pos);
                                 break;
                             }
                         }
@@ -1175,10 +1434,10 @@ pub async fn run_scrcpy(window: Window, state: State<'_, ScrcpyState>, config: S
                             "scrcpy-log",
                             "[SYSTEM] No compatible audio codec found. Consider disabling audio forwarding.".to_string(),
                         );
-                        let _ = window_mon.emit("scrcpy-status", json!({ "device": device_mon, "running": false }));
+                        emit_window_pos_and_stop(&window_mon, &device_mon, requested_pos, first_window_pos, last_window_pos);
                         break;
                     } else {
-                        let _ = window_mon.emit("scrcpy-status", json!({ "device": device_mon, "running": false }));
+                        emit_window_pos_and_stop(&window_mon, &device_mon, requested_pos, first_window_pos, last_window_pos);
                         break;
                     }
                 }
@@ -1229,6 +1488,8 @@ mod tests {
             background_color: None,
             keep_active: None,
             vsync: None,
+            window_x: None,
+            window_y: None,
         }
     }
 
@@ -1322,6 +1583,121 @@ mod tests {
         assert!(!is_audio_codec_error("video encoder error"));
         assert!(!is_audio_codec_error("permission issue"));
         assert!(!is_audio_codec_error("INFO Audio codec selected: opus"));
+    }
+
+    #[test]
+    fn test_build_scrcpy_args_window_position() {
+        let mut config = base_config("mirror");
+        config.window_x = Some(100);
+        config.window_y = Some(200);
+        let args = build_scrcpy_args(&config, None, None);
+        assert!(args.contains(&"--window-x=100".to_string()));
+        assert!(args.contains(&"--window-y=200".to_string()));
+    }
+
+    #[test]
+    fn test_build_scrcpy_args_window_position_negative_coords() {
+        // Multi-monitor: a display left of / above the primary yields negative
+        // coordinates, which scrcpy accepts.
+        let mut config = base_config("mirror");
+        config.window_x = Some(-1920);
+        config.window_y = Some(0);
+        let args = build_scrcpy_args(&config, None, None);
+        assert!(args.contains(&"--window-x=-1920".to_string()));
+        assert!(args.contains(&"--window-y=0".to_string()));
+    }
+
+    #[test]
+    fn test_build_scrcpy_args_window_position_skipped_in_fullscreen() {
+        let mut config = base_config("mirror");
+        config.window_x = Some(100);
+        config.window_y = Some(200);
+        config.fullscreen = Some(true);
+        let args = build_scrcpy_args(&config, None, None);
+        assert!(!args.iter().any(|a| a.starts_with("--window-x")));
+        assert!(!args.iter().any(|a| a.starts_with("--window-y")));
+    }
+
+    #[test]
+    fn test_build_scrcpy_args_window_position_only_mirror() {
+        // Camera (and desktop) sessions must not receive the mirror window's
+        // remembered position, it is scoped to mirror mode.
+        let mut config = base_config("camera");
+        config.window_x = Some(100);
+        config.window_y = Some(200);
+        let args = build_scrcpy_args(&config, None, None);
+        assert!(!args.iter().any(|a| a.starts_with("--window-x")));
+        assert!(!args.iter().any(|a| a.starts_with("--window-y")));
+    }
+
+    #[test]
+    fn test_parse_shell_var_int() {
+        let text = "WINDOW=12345\nX=959\nY=24\nWIDTH=428\nHEIGHT=928\n";
+        assert_eq!(parse_shell_var_int(text, "X"), Some(959));
+        assert_eq!(parse_shell_var_int(text, "Y"), Some(24));
+        assert_eq!(parse_shell_var_int(text, "MISSING"), None);
+    }
+
+    #[test]
+    fn test_resolve_window_pos_first_launch_uses_raw() {
+        // First launch ever (nothing requested): persist the raw last sample.
+        assert_eq!(
+            resolve_window_pos_to_persist(None, Some((100, 72)), (300, 222)),
+            (300, 222)
+        );
+        assert_eq!(
+            resolve_window_pos_to_persist(None, None, (300, 222)),
+            (300, 222)
+        );
+    }
+
+    #[test]
+    fn test_resolve_window_pos_zero_offset_is_noop() {
+        // Windows/Linux: the tool already reports the client origin, so the
+        // first sample matches what we requested -> offset 0 -> last unchanged.
+        let requested = Some((100, 100));
+        let first = Some((100, 100));
+        assert_eq!(
+            resolve_window_pos_to_persist(requested, first, (640, 480)),
+            (640, 480)
+        );
+    }
+
+    #[test]
+    fn test_resolve_window_pos_cancels_titlebar_offset() {
+        // macOS-like: the tool reports the frame origin (title-bar top), 28 px
+        // above the client origin scrcpy positions. Requested (100,100) but
+        // first observed (100,72); the -28 px offset must be cancelled so the
+        // persisted value maps back to the client origin.
+        let requested = Some((100, 100));
+        let first = Some((100, 72));
+        assert_eq!(
+            resolve_window_pos_to_persist(requested, first, (300, 222)),
+            (300, 250)
+        );
+    }
+
+    #[test]
+    fn test_resolve_window_pos_cancels_full_frame_offset() {
+        // Frame offset on both axes (border + title bar).
+        let requested = Some((100, 100));
+        let first = Some((92, 69));
+        assert_eq!(
+            resolve_window_pos_to_persist(requested, first, (292, 219)),
+            (300, 250)
+        );
+    }
+
+    #[test]
+    fn test_resolve_window_pos_ignores_implausible_offset() {
+        // The window was moved before the first sample (or placed by the WM):
+        // the offset dwarfs any window decoration, so fall back to the raw last.
+        let requested = Some((100, 100));
+        let first = Some((900, 700));
+        assert_eq!(
+            resolve_window_pos_to_persist(requested, first, (950, 760)),
+            (950, 760)
+        );
     }
 
     #[test]
@@ -1436,6 +1812,15 @@ pub async fn stop_scrcpy(state: State<'_, ScrcpyState>, device: String) -> Resul
 
     if let Some(mut c) = child {
         if let Some(pid) = c.id() {
+             // Grab the window's position now, one last time, before it's
+             // killed: this is the only moment it's guaranteed to still be
+             // exactly where the user left it. The run_scrcpy monitor loop
+             // only refreshes its own sample every ~3s, so stopping right
+             // after a move could otherwise persist a stale, pre-move spot.
+             if let Some(pos) = try_capture_window_pos(pid) {
+                 state.final_capture_hint.lock().unwrap().insert(device.clone(), pos);
+             }
+
              #[cfg(target_os = "windows")]
              {
                 let _ = StdCommand::new("taskkill")
@@ -1443,7 +1828,7 @@ pub async fn stop_scrcpy(state: State<'_, ScrcpyState>, device: String) -> Resul
                     .creation_flags(CREATE_NO_WINDOW)
                     .output();
              }
-             
+
              #[cfg(not(target_os = "windows"))]
              {
                  // Try graceful termination first via SIGTERM

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -758,6 +758,56 @@ fn parse_shell_var_int(text: &str, key: &str) -> Option<i32> {
         .and_then(|l| l[prefix.len()..].trim().parse().ok())
 }
 
+/// Windows: finds the first visible, unowned top-level window belonging to
+/// process `pid` (matches .NET's `MainWindowHandle` heuristic), i.e. scrcpy's
+/// SDL mirror window rather than some owned tool/popup window. Shared by the
+/// position-capture and recenter paths so both agree on which window they
+/// mean.
+#[cfg(target_os = "windows")]
+fn find_window_by_pid(pid: u32) -> Option<windows::Win32::Foundation::HWND> {
+    use windows::core::BOOL;
+    use windows::Win32::Foundation::{HWND, LPARAM};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetWindow, GetWindowThreadProcessId, IsWindowVisible, GW_OWNER,
+    };
+
+    // State threaded through EnumWindows via LPARAM.
+    struct Search {
+        target_pid: u32,
+        found: HWND,
+    }
+
+    // WNDENUMPROC: BOOL(1) keeps enumerating, BOOL(0) stops.
+    unsafe extern "system" fn enum_proc(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        let search = &mut *(lparam.0 as *mut Search);
+        if !IsWindowVisible(hwnd).as_bool() {
+            return BOOL(1);
+        }
+        if GetWindow(hwnd, GW_OWNER).map(|o| !o.0.is_null()).unwrap_or(false) {
+            return BOOL(1);
+        }
+        let mut wnd_pid: u32 = 0;
+        let _ = GetWindowThreadProcessId(hwnd, Some(&mut wnd_pid as *mut u32));
+        if wnd_pid == search.target_pid {
+            search.found = hwnd;
+            return BOOL(0); // found it -> stop enumeration
+        }
+        BOOL(1)
+    }
+
+    let mut search = Search {
+        target_pid: pid,
+        found: HWND::default(),
+    };
+    // EnumWindows returns Err both on real failure and when the callback
+    // returns BOOL(0) (our intentional early stop), so ignore the Result and
+    // read the captured handle instead.
+    unsafe {
+        let _ = EnumWindows(Some(enum_proc), LPARAM(&mut search as *mut Search as isize));
+    }
+    (!search.found.0.is_null()).then_some(search.found)
+}
+
 /// Queries the on-screen position of the scrcpy SDL window owned by process
 /// `pid`, returning the client-area top-left in screen pixels. Returns `None`
 /// silently whenever the window can't be read (not created yet, minimized,
@@ -772,56 +822,14 @@ fn parse_shell_var_int(text: &str, key: &str) -> Option<i32> {
 fn try_capture_window_pos(pid: u32) -> Option<(i32, i32)> {
     #[cfg(target_os = "windows")]
     {
-        // Native Win32: find this PID's main window and read its client-area
-        // origin. This replaces spawning PowerShell + `Add-Type` (a C# JIT) on
-        // every poll, it is a couple of direct syscalls with no child process.
-        use windows::core::BOOL;
-        use windows::Win32::Foundation::{HWND, LPARAM, POINT};
+        // Native Win32: this replaces spawning PowerShell + `Add-Type` (a C#
+        // JIT) on every poll, it is a couple of direct syscalls with no child
+        // process.
+        use windows::Win32::Foundation::POINT;
         use windows::Win32::Graphics::Gdi::ClientToScreen;
-        use windows::Win32::UI::WindowsAndMessaging::{
-            EnumWindows, GetWindow, GetWindowThreadProcessId, IsIconic, IsWindowVisible, IsZoomed,
-            GW_OWNER,
-        };
+        use windows::Win32::UI::WindowsAndMessaging::{IsIconic, IsZoomed};
 
-        // State threaded through EnumWindows via LPARAM.
-        struct Search {
-            target_pid: u32,
-            found: HWND,
-        }
-
-        // WNDENUMPROC: BOOL(1) keeps enumerating, BOOL(0) stops.
-        unsafe extern "system" fn enum_proc(hwnd: HWND, lparam: LPARAM) -> BOOL {
-            let search = &mut *(lparam.0 as *mut Search);
-            // Match .NET's MainWindowHandle heuristic: the first visible, unowned
-            // top-level window of the process, i.e. scrcpy's SDL mirror window,
-            // not an owned tool/popup window.
-            if !IsWindowVisible(hwnd).as_bool() {
-                return BOOL(1);
-            }
-            if GetWindow(hwnd, GW_OWNER).map(|o| !o.0.is_null()).unwrap_or(false) {
-                return BOOL(1);
-            }
-            let mut wnd_pid: u32 = 0;
-            let _ = GetWindowThreadProcessId(hwnd, Some(&mut wnd_pid as *mut u32));
-            if wnd_pid == search.target_pid {
-                search.found = hwnd;
-                return BOOL(0); // found it -> stop enumeration
-            }
-            BOOL(1)
-        }
-
-        let mut search = Search {
-            target_pid: pid,
-            found: HWND::default(),
-        };
-        // EnumWindows returns Err both on real failure and when the callback
-        // returns BOOL(0) (our intentional early stop), so ignore the Result
-        // and read the captured handle instead.
-        unsafe {
-            let _ = EnumWindows(Some(enum_proc), LPARAM(&mut search as *mut Search as isize));
-        }
-        let hwnd = search.found;
-        if !hwnd.0.is_null() {
+        if let Some(hwnd) = find_window_by_pid(pid) {
             // A minimized window reports an off-screen sentinel origin
             // (~ -32000,-32000) and a maximized one the monitor edge; neither is
             // the windowed position we want, so skip them and keep the last good
@@ -885,6 +893,148 @@ fn try_capture_window_pos(pid: u32) -> Option<(i32, i32)> {
     #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
     let _ = pid;
     None
+}
+
+/// Moves the scrcpy mirror window owned by `pid` to the centre of the primary
+/// screen and brings it to the front. A safety net for a persisted position
+/// that no longer lands on any connected monitor (e.g. it was saved while a
+/// second monitor was attached, which has since been unplugged) -- the window
+/// can reopen fully off-screen, with no title bar to drag back if borderless.
+/// Best-effort and silent: does nothing if the window can't be found, is
+/// already maximized (it fills its monitor; there is nothing to recover), or
+/// the move fails.
+fn recenter_window(pid: u32) {
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::Foundation::RECT;
+        use windows::Win32::UI::WindowsAndMessaging::{
+            GetSystemMetrics, GetWindowRect, IsIconic, IsZoomed, SetForegroundWindow,
+            SetWindowPos, ShowWindow, SM_CXSCREEN, SM_CYSCREEN, SWP_NOSIZE, SWP_NOZORDER,
+            SW_RESTORE,
+        };
+
+        let Some(hwnd) = find_window_by_pid(pid) else {
+            return;
+        };
+        if unsafe { IsZoomed(hwnd) }.as_bool() {
+            return;
+        }
+        if unsafe { IsIconic(hwnd) }.as_bool() {
+            let _ = unsafe { ShowWindow(hwnd, SW_RESTORE) };
+        }
+        let mut rect = RECT::default();
+        if unsafe { GetWindowRect(hwnd, &mut rect) }.is_err() {
+            return;
+        }
+        let (w, h) = (rect.right - rect.left, rect.bottom - rect.top);
+        let (screen_w, screen_h) =
+            unsafe { (GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN)) };
+        let _ = unsafe {
+            SetWindowPos(
+                hwnd,
+                None,
+                (screen_w - w) / 2,
+                (screen_h - h) / 2,
+                0,
+                0,
+                SWP_NOSIZE | SWP_NOZORDER,
+            )
+        };
+        let _ = unsafe { SetForegroundWindow(hwnd) };
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let pid_str = pid.to_string();
+        let Ok(search_out) = StdCommand::new("xdotool").args(["search", "--pid", &pid_str]).output() else {
+            return;
+        };
+        let Some(window_id) = String::from_utf8_lossy(&search_out.stdout).lines().next().map(str::to_string) else {
+            return;
+        };
+
+        let Ok(geom_out) = StdCommand::new("xdotool")
+            .args(["getwindowgeometry", "--shell", &window_id])
+            .output()
+        else {
+            return;
+        };
+        let geom_text = String::from_utf8_lossy(&geom_out.stdout);
+        let (Some(w), Some(h)) = (
+            parse_shell_var_int(&geom_text, "WIDTH"),
+            parse_shell_var_int(&geom_text, "HEIGHT"),
+        ) else {
+            return;
+        };
+
+        let Ok(display_out) = StdCommand::new("xdotool").arg("getdisplaygeometry").output() else {
+            return;
+        };
+        let display_text = String::from_utf8_lossy(&display_out.stdout);
+        let mut parts = display_text.split_whitespace();
+        let (Some(Ok(screen_w)), Some(Ok(screen_h))) = (
+            parts.next().map(str::parse::<i32>),
+            parts.next().map(str::parse::<i32>),
+        ) else {
+            return;
+        };
+
+        let x = ((screen_w - w).max(0) / 2).to_string();
+        let y = ((screen_h - h).max(0) / 2).to_string();
+        let _ = StdCommand::new("xdotool").args(["windowmove", &window_id, &x, &y]).output();
+        let _ = StdCommand::new("xdotool").args(["windowactivate", &window_id]).output();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // Same Accessibility-permission requirement as the position capture
+        // above; a silent no-op until it is granted.
+        let script = format!(
+            concat!(
+                "tell application \"System Events\"\n",
+                "try\n",
+                "set proc to first process whose unix id is {}\n",
+                "set win to first window of proc\n",
+                "set {{winW, winH}} to size of win\n",
+                "tell application \"Finder\" to set screenBounds to bounds of window of desktop\n",
+                "set screenW to (item 3 of screenBounds)\n",
+                "set screenH to (item 4 of screenBounds)\n",
+                "set position of win to {{((screenW - winW) / 2), ((screenH - winH) / 2)}}\n",
+                "set frontmost of proc to true\n",
+                "end try\n",
+                "end tell"
+            ),
+            pid
+        );
+        let _ = StdCommand::new("osascript").args(["-e", &script]).output();
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+    let _ = pid;
+}
+
+/// Re-centres the running mirror window for `device` on the primary screen.
+/// Bound to a global OS shortcut (Ctrl+Alt+Shift+C, see `shortcuts.rs`) so a
+/// window whose saved position ends up off-screen (see [`recenter_window`])
+/// can be recovered without being able to see or focus it directly. A no-op
+/// if `device` has no tracked process (e.g. nothing is running).
+pub fn recenter_device(state: &ScrcpyState, device: &str) {
+    let pid = state.processes.lock().unwrap().get(device).and_then(|c| c.id());
+    if let Some(pid) = pid {
+        recenter_window(pid);
+    }
+}
+
+#[tauri::command]
+pub fn recenter_scrcpy_window(state: State<'_, ScrcpyState>, device: String) -> Result<(), String> {
+    recenter_device(&state, &device);
+    Ok(())
+}
+
+/// Records which device the GUI currently considers selected, so the global
+/// recentre shortcut (which fires with no window necessarily focused) knows
+/// which mirror window to act on.
+#[tauri::command]
+pub fn set_active_device(state: State<'_, ScrcpyState>, device: Option<String>) -> Result<(), String> {
+    *state.active_device.lock().unwrap() = device;
+    Ok(())
 }
 
 /// Converts a raw captured position into the value to persist as

--- a/src-tauri/src/grab.rs
+++ b/src-tauri/src/grab.rs
@@ -1,0 +1,236 @@
+//! Windows-only: drag the borderless scrcpy mirror window with the mouse.
+//!
+//! scrcpy's `--window-borderless` window has no title bar, and Windows, unlike
+//! GNOME/KDE, which provide Super/Meta+drag, has no built-in way to move such a
+//! window. (A title bar can't simply be added from the outside either: scrcpy's
+//! SDL window owns its non-client area, so an externally-set WS_CAPTION never
+//! renders.) This registers a global shortcut (Ctrl+Alt+Shift+W) that "grabs"
+//! the focused scrcpy window: the cursor jumps to the window's centre and the
+//! window then follows the mouse. Drop it with a left click or by pressing the
+//! shortcut again. The window is moved from the outside via Win32 `SetWindowPos`;
+//! scrcpy itself is never touched.
+//!
+//! Self-contained on purpose: the whole feature lives in this module plus a
+//! small hook in `lib.rs` and one target-gated dependency, so it is easy to
+//! review, or to split out into its own change.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use tauri::plugin::TauriPlugin;
+use tauri::{AppHandle, Manager, Runtime};
+use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
+
+use windows::Win32::Foundation::{HINSTANCE, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM};
+use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+use windows::Win32::UI::WindowsAndMessaging::{
+    CallNextHookEx, GetCursorPos, GetForegroundWindow, GetWindowRect, GetWindowThreadProcessId,
+    IsZoomed, PeekMessageW, SetCursorPos, SetWindowsHookExW, SetWindowPos, UnhookWindowsHookEx,
+    HC_ACTION, HHOOK, MSG, PM_REMOVE, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER, WH_MOUSE_LL,
+    WM_LBUTTONDOWN,
+};
+
+use crate::ScrcpyState;
+
+/// Whether a grab is in progress. Flipped by the shortcut handler, ended by the
+/// mouse hook on a left click, and polled by the follow thread. A module static
+/// (not managed state) so the C-style hook procedure, which cannot capture, can
+/// reach it.
+static GRAB_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+// Ctrl+Alt+Shift+W, all four keys sit under the left hand, so it is a
+// one-handed shortcut. RegisterHotKey makes the combo global (consumed
+// system-wide while registered), so it is deliberately an uncommon four-key
+// chord that steers clear of scrcpy's own shortcuts (all MOD(Alt/Super)+key)
+// and the GUI's (none).
+fn toggle_shortcut() -> Shortcut {
+    Shortcut::new(
+        Some(Modifiers::CONTROL | Modifiers::ALT | Modifiers::SHIFT),
+        Code::KeyW,
+    )
+}
+
+/// The global-shortcut plugin, wired to toggle the grab. Add this on the Tauri
+/// builder (its setup wires the OS hotkey manager on the main thread).
+pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
+    tauri_plugin_global_shortcut::Builder::new()
+        .with_handler(|_app, _shortcut, event| {
+            // Only one shortcut is ever registered here, so any pressed event is
+            // ours. Toggle on the key-down edge only.
+            if event.state() == ShortcutState::Pressed {
+                GRAB_ACTIVE.fetch_xor(true, Ordering::SeqCst);
+            }
+        })
+        .build()
+}
+
+/// Register the shortcut and start the follow thread. Call from the app's
+/// `setup` (main thread).
+pub fn register<R: Runtime>(app: &AppHandle<R>) -> Result<(), Box<dyn std::error::Error>> {
+    app.global_shortcut().register(toggle_shortcut())?;
+    let handle = app.clone();
+    std::thread::spawn(move || follow_loop(handle));
+    Ok(())
+}
+
+/// Background loop: while a grab is active, keep the grabbed window under the
+/// cursor and watch for the left-click that drops it. Sleeps cheaply when idle.
+fn follow_loop<R: Runtime>(app: AppHandle<R>) {
+    // Everything below runs on this one thread: the raw HWND in `grabbed` and the
+    // mouse hook both stay thread-local.
+    let mut grabbed: Option<GrabbedWindow> = None;
+    let mut hook: Option<HHOOK> = None;
+
+    loop {
+        if !GRAB_ACTIVE.load(Ordering::SeqCst) {
+            release_hook(&mut hook);
+            grabbed = None;
+            std::thread::sleep(Duration::from_millis(40));
+            continue;
+        }
+
+        // Arm on the first tick of a new grab: attach to the focused window (only
+        // if it is one of our scrcpy windows) and install the click-to-drop hook.
+        if grabbed.is_none() {
+            match GrabbedWindow::arm(&app) {
+                Some(g) => {
+                    grabbed = Some(g);
+                    hook = install_hook();
+                }
+                None => {
+                    GRAB_ACTIVE.store(false, Ordering::SeqCst);
+                    continue;
+                }
+            }
+        }
+
+        // Pump this thread's queue so the low-level mouse hook can fire, then move
+        // the window to follow the cursor.
+        pump_messages();
+        if let Some(g) = &grabbed {
+            if !g.follow_cursor() {
+                // The window went away (e.g. session closed): end the grab.
+                GRAB_ACTIVE.store(false, Ordering::SeqCst);
+                release_hook(&mut hook);
+                grabbed = None;
+                continue;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(6));
+    }
+}
+
+/// A window being dragged, plus the cursor-to-window-corner offset captured when
+/// the grab started, so the grab point stays under the cursor.
+struct GrabbedWindow {
+    hwnd: HWND,
+    offset: (i32, i32),
+}
+
+impl GrabbedWindow {
+    fn arm<R: Runtime>(app: &AppHandle<R>) -> Option<GrabbedWindow> {
+        let fg = unsafe { GetForegroundWindow() };
+        if fg.0.is_null() {
+            return None;
+        }
+        let mut pid: u32 = 0;
+        unsafe { GetWindowThreadProcessId(fg, Some(&mut pid)) };
+        if pid == 0 || !pid_is_ours(app, pid) {
+            return None;
+        }
+        // Refuse a maximized window: SetWindowPos with SWP_NOSIZE would drag it
+        // around still-maximized (monitor-sized) and partly off-screen. Restore
+        // it first (e.g. Win+Down) to move it.
+        if unsafe { IsZoomed(fg) }.as_bool() {
+            return None;
+        }
+        let mut rect = RECT::default();
+        if unsafe { GetWindowRect(fg, &mut rect) }.is_err() {
+            return None;
+        }
+        // Warp the cursor to the window's centre and grab from there. Grabbing
+        // from wherever the cursor happens to be would run out of cursor travel
+        // on that side (you couldn't drag the window past that screen edge);
+        // centring gives room to move in every direction and lets the window
+        // reach all four edges.
+        let centre = ((rect.left + rect.right) / 2, (rect.top + rect.bottom) / 2);
+        let _ = unsafe { SetCursorPos(centre.0, centre.1) };
+        Some(GrabbedWindow {
+            hwnd: fg,
+            offset: (centre.0 - rect.left, centre.1 - rect.top),
+        })
+    }
+
+    /// Move the window so the grab point stays under the cursor. Returns false
+    /// only when the window can no longer be moved (e.g. it was closed).
+    fn follow_cursor(&self) -> bool {
+        // A transient cursor-read failure should not drop the grab.
+        let Some((cx, cy)) = cursor_pos() else {
+            return true;
+        };
+        unsafe {
+            SetWindowPos(
+                self.hwnd,
+                None,
+                cx - self.offset.0,
+                cy - self.offset.1,
+                0,
+                0,
+                SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
+            )
+        }
+        .is_ok()
+    }
+}
+
+/// Low-level mouse hook: while a grab is active, a left-button press ends it and
+/// is swallowed, so the click that "drops" the window is not forwarded to scrcpy
+/// as a tap on the phone.
+unsafe extern "system" fn mouse_hook(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+    if code == HC_ACTION as i32
+        && wparam.0 as u32 == WM_LBUTTONDOWN
+        && GRAB_ACTIVE.load(Ordering::SeqCst)
+    {
+        GRAB_ACTIVE.store(false, Ordering::SeqCst);
+        return LRESULT(1); // handled -> do not pass the click to scrcpy
+    }
+    CallNextHookEx(None, code, wparam, lparam)
+}
+
+fn install_hook() -> Option<HHOOK> {
+    // WH_MOUSE_LL is global; it is installed only for the duration of a grab.
+    let hmod = unsafe { GetModuleHandleW(None) }.ok()?;
+    unsafe { SetWindowsHookExW(WH_MOUSE_LL, Some(mouse_hook), Some(HINSTANCE(hmod.0)), 0) }.ok()
+}
+
+fn release_hook(hook: &mut Option<HHOOK>) {
+    if let Some(h) = hook.take() {
+        let _ = unsafe { UnhookWindowsHookEx(h) };
+    }
+}
+
+/// Pump the thread's message queue so the installed low-level hook can fire
+/// (low-level hooks are delivered while the thread retrieves messages).
+fn pump_messages() {
+    let mut msg = MSG::default();
+    while unsafe { PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE) }.as_bool() {}
+}
+
+/// True if `pid` is one of the scrcpy processes we launched.
+fn pid_is_ours<R: Runtime>(app: &AppHandle<R>, pid: u32) -> bool {
+    app.state::<ScrcpyState>()
+        .processes
+        .lock()
+        .unwrap()
+        .values()
+        .any(|child| child.id() == Some(pid))
+}
+
+fn cursor_pos() -> Option<(i32, i32)> {
+    let mut p = POINT::default();
+    if unsafe { GetCursorPos(&mut p) }.is_ok() {
+        Some((p.x, p.y))
+    } else {
+        None
+    }
+}

--- a/src-tauri/src/grab.rs
+++ b/src-tauri/src/grab.rs
@@ -17,9 +17,8 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use tauri::plugin::TauriPlugin;
 use tauri::{AppHandle, Manager, Runtime};
-use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
+use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut};
 
 use windows::Win32::Foundation::{HINSTANCE, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM};
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
@@ -43,34 +42,24 @@ static GRAB_ACTIVE: AtomicBool = AtomicBool::new(false);
 // system-wide while registered), so it is deliberately an uncommon four-key
 // chord that steers clear of scrcpy's own shortcuts (all MOD(Alt/Super)+key)
 // and the GUI's (none).
-fn toggle_shortcut() -> Shortcut {
+pub fn toggle_shortcut() -> Shortcut {
     Shortcut::new(
         Some(Modifiers::CONTROL | Modifiers::ALT | Modifiers::SHIFT),
         Code::KeyW,
     )
 }
 
-/// The global-shortcut plugin, wired to toggle the grab. Add this on the Tauri
-/// builder (its setup wires the OS hotkey manager on the main thread).
-pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
-    tauri_plugin_global_shortcut::Builder::new()
-        .with_handler(|_app, _shortcut, event| {
-            // Only one shortcut is ever registered here, so any pressed event is
-            // ours. Toggle on the key-down edge only.
-            if event.state() == ShortcutState::Pressed {
-                GRAB_ACTIVE.fetch_xor(true, Ordering::SeqCst);
-            }
-        })
-        .build()
+/// Flip the grab on/off. Called from `shortcuts.rs`'s shared global-shortcut
+/// handler on the key-down edge of [`toggle_shortcut`].
+pub fn toggle() {
+    GRAB_ACTIVE.fetch_xor(true, Ordering::SeqCst);
 }
 
-/// Register the shortcut and start the follow thread. Call from the app's
-/// `setup` (main thread).
-pub fn register<R: Runtime>(app: &AppHandle<R>) -> Result<(), Box<dyn std::error::Error>> {
-    app.global_shortcut().register(toggle_shortcut())?;
+/// Start the follow thread. Call from the app's `setup` (main thread); the
+/// shortcut itself is registered by `shortcuts.rs`.
+pub fn register<R: Runtime>(app: &AppHandle<R>) {
     let handle = app.clone();
     std::thread::spawn(move || follow_loop(handle));
-    Ok(())
 }
 
 /// Background loop: while a grab is active, keep the grabbed window under the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,13 @@ use std::os::unix::process::CommandExt;
 
 pub struct ScrcpyState {
     pub processes: Mutex<HashMap<String, Child>>,
+    /// A raw window position captured by `stop_scrcpy` right before it kills
+    /// the process (the window is still exactly where the user left it at
+    /// that instant), handed off to the run_scrcpy monitor loop so it can
+    /// apply its already-learned decoration offset instead of persisting its
+    /// own periodic sample, which can be a few seconds stale. See
+    /// `resolve_window_pos_to_persist` in commands.rs.
+    pub final_capture_hint: Mutex<HashMap<String, (i32, i32)>>,
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -61,6 +68,7 @@ pub fn run() {
         .setup(|app| {
             app.manage(ScrcpyState {
                 processes: Mutex::new(HashMap::new()),
+                final_capture_hint: Mutex::new(HashMap::new()),
             });
 
             // Show splashscreen instantly

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,8 @@
 mod commands;
+// Windows-only: drag the borderless scrcpy window with the mouse
+// (Ctrl+Alt+Shift+W).
+#[cfg(target_os = "windows")]
+mod grab;
 use std::collections::HashMap;
 use std::sync::Mutex;
 use tauri::Manager;
@@ -62,14 +66,29 @@ pub fn run() {
         }
     }
 
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
-        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_dialog::init());
+
+    // Windows-only: the global-shortcut plugin must be registered on the builder
+    // (its setup wires the OS hotkey manager on the main thread). The shortcut
+    // itself is registered below in setup.
+    #[cfg(target_os = "windows")]
+    let builder = builder.plugin(grab::plugin());
+
+    builder
         .setup(|app| {
             app.manage(ScrcpyState {
                 processes: Mutex::new(HashMap::new()),
                 final_capture_hint: Mutex::new(HashMap::new()),
             });
+
+            // Windows-only: enable Ctrl+Alt+Shift+W to drag the borderless
+            // scrcpy window with the mouse. Non-fatal if it fails to register.
+            #[cfg(target_os = "windows")]
+            if let Err(e) = grab::register(app.handle()) {
+                eprintln!("[grab] failed to register window-move shortcut: {e}");
+            }
 
             // Show splashscreen instantly
             if let Some(splash_window) = app.get_webview_window("splashscreen") {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,9 @@ mod commands;
 // (Ctrl+Alt+Shift+W).
 #[cfg(target_os = "windows")]
 mod grab;
+// Cross-platform global OS shortcuts (e.g. Ctrl+Alt+Shift+C to recentre the
+// active mirror window), shared with grab.rs's Windows-only drag toggle.
+mod shortcuts;
 use std::collections::HashMap;
 use std::sync::Mutex;
 use tauri::Manager;
@@ -13,6 +16,7 @@ use std::os::unix::process::CommandExt;
 
 pub struct ScrcpyState {
     pub processes: Mutex<HashMap<String, Child>>,
+    pub active_device: Mutex<Option<String>>,
     /// A raw window position captured by `stop_scrcpy` right before it kills
     /// the process (the window is still exactly where the user left it at
     /// that instant), handed off to the run_scrcpy monitor loop so it can
@@ -68,27 +72,30 @@ pub fn run() {
 
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
-        .plugin(tauri_plugin_dialog::init());
-
-    // Windows-only: the global-shortcut plugin must be registered on the builder
-    // (its setup wires the OS hotkey manager on the main thread). The shortcut
-    // itself is registered below in setup.
-    #[cfg(target_os = "windows")]
-    let builder = builder.plugin(grab::plugin());
+        .plugin(tauri_plugin_dialog::init())
+        // The global-shortcut plugin must be registered on the builder (its
+        // setup wires the OS hotkey manager on the main thread). Individual
+        // shortcuts are registered below in setup.
+        .plugin(shortcuts::plugin());
 
     builder
         .setup(|app| {
             app.manage(ScrcpyState {
                 processes: Mutex::new(HashMap::new()),
+                active_device: Mutex::new(None),
                 final_capture_hint: Mutex::new(HashMap::new()),
             });
 
-            // Windows-only: enable Ctrl+Alt+Shift+W to drag the borderless
-            // scrcpy window with the mouse. Non-fatal if it fails to register.
-            #[cfg(target_os = "windows")]
-            if let Err(e) = grab::register(app.handle()) {
-                eprintln!("[grab] failed to register window-move shortcut: {e}");
+            // Ctrl+Alt+Shift+C (recentre the active mirror window) on every
+            // platform, plus Ctrl+Alt+Shift+W (drag the borderless window) on
+            // Windows. Non-fatal if a shortcut fails to register.
+            if let Err(e) = shortcuts::register(app.handle()) {
+                eprintln!("[shortcuts] failed to register global shortcuts: {e}");
             }
+
+            // Windows-only: start the drag-follow thread backing Ctrl+Alt+Shift+W.
+            #[cfg(target_os = "windows")]
+            grab::register(app.handle());
 
             // Show splashscreen instantly
             if let Some(splash_window) = app.get_webview_window("splashscreen") {
@@ -110,6 +117,8 @@ pub fn run() {
             commands::kill_adb,
             commands::run_scrcpy,
             commands::stop_scrcpy,
+            commands::recenter_scrcpy_window,
+            commands::set_active_device,
             commands::download_scrcpy,
             commands::list_scrcpy_options,
             commands::get_render_drivers,

--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -1,0 +1,63 @@
+//! Cross-platform global OS shortcuts. `tauri_plugin_global_shortcut` only
+//! supports one plugin instance (and so one dispatch handler) per app, so this
+//! module owns the shared plugin/handler and dispatches by shortcut identity,
+//! rather than each feature registering its own plugin.
+//!
+//! Windows' borderless-window drag (Ctrl+Alt+Shift+W, see `grab.rs`) is the
+//! other shortcut sharing this plugin; its own toggle is exposed as a plain
+//! function so this module can dispatch into it without owning any of its
+//! drag-follow implementation.
+
+use tauri::plugin::TauriPlugin;
+use tauri::{AppHandle, Manager, Runtime};
+use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
+
+use crate::ScrcpyState;
+
+/// Ctrl+Alt+Shift+C: snap the active device's mirror window back to the
+/// centre of the screen. A true OS-level global shortcut, so it works
+/// regardless of which window (if any) currently has keyboard focus -- unlike
+/// a webview `keydown` listener, which only fires while the app's own window
+/// is focused.
+fn recenter_shortcut() -> Shortcut {
+    Shortcut::new(
+        Some(Modifiers::CONTROL | Modifiers::ALT | Modifiers::SHIFT),
+        Code::KeyC,
+    )
+}
+
+/// The global-shortcut plugin, wired to dispatch every registered shortcut by
+/// identity. Add this on the Tauri builder (its setup wires the OS hotkey
+/// manager on the main thread).
+pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
+    tauri_plugin_global_shortcut::Builder::new()
+        .with_handler(|app, shortcut, event| {
+            if event.state() != ShortcutState::Pressed {
+                return;
+            }
+            if shortcut == &recenter_shortcut() {
+                recenter_active_device(app);
+            }
+            #[cfg(target_os = "windows")]
+            if shortcut == &crate::grab::toggle_shortcut() {
+                crate::grab::toggle();
+            }
+        })
+        .build()
+}
+
+/// Register every global shortcut. Call from the app's `setup` (main thread).
+pub fn register<R: Runtime>(app: &AppHandle<R>) -> Result<(), Box<dyn std::error::Error>> {
+    app.global_shortcut().register(recenter_shortcut())?;
+    #[cfg(target_os = "windows")]
+    app.global_shortcut().register(crate::grab::toggle_shortcut())?;
+    Ok(())
+}
+
+fn recenter_active_device<R: Runtime>(app: &AppHandle<R>) {
+    let state = app.state::<ScrcpyState>();
+    let device = state.active_device.lock().unwrap().clone();
+    if let Some(device) = device {
+        crate::commands::recenter_device(&state, &device);
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -187,6 +187,18 @@ function App() {
   }, [activeDevice]);
 
   useEffect(() => {
+    // Keep the Rust side's notion of "the selected device" in sync, so the
+    // Ctrl+Alt+Shift+C global shortcut (a real OS-level hotkey registered in
+    // shortcuts.rs, not a webview keydown listener) knows which mirror window
+    // to recentre even when no app window has keyboard focus.
+    const device = activeDevice && runningDevices.includes(activeDevice) ? activeDevice : null;
+    (async () => {
+      const { invoke } = await import('@tauri-apps/api/core');
+      await invoke('set_active_device', { device });
+    })();
+  }, [activeDevice, runningDevices]);
+
+  useEffect(() => {
     if (activeDevice) {
       setConfig(prev => ({ ...prev, device: activeDevice }));
     }

--- a/src/components/SessionBehavior.tsx
+++ b/src/components/SessionBehavior.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { open } from '@tauri-apps/plugin-dialog';
 import { ScrcpyConfig } from '../hooks/useScrcpy';
 import Tooltip from './Tooltip';
-import { Coffee, MonitorOff, Volume2, Layers, Maximize, Square, Circle, Folder, Settings2, ChevronDown, ActivitySquare } from 'lucide-react';
+import { Coffee, MonitorOff, Volume2, Layers, Maximize, Square, Circle, Folder, Settings2, ChevronDown, ActivitySquare, Move } from 'lucide-react';
 import { useI18n } from '../i18n';
 
 const AUDIO_CODEC_VALUES = ['auto', 'opus', 'aac', 'flac', 'raw'] as const;
@@ -191,6 +191,13 @@ export default function SessionBehavior({ config, setConfig }: SessionBehaviorPr
                         icon={Square}
                         label={t('sessionBehavior.borderless')}
                         tooltip={t('sessionBehavior.borderlessTooltip')}
+                    />
+                    <Toggle
+                        checked={config.rememberWindowPosition !== false}
+                        onChange={(v) => handleChange('rememberWindowPosition', v)}
+                        icon={Move}
+                        label={t('sessionBehavior.rememberWindowPosition')}
+                        tooltip={t('sessionBehavior.rememberWindowPositionTooltip')}
                     />
                     <Toggle
                         checked={config.record || false}

--- a/src/hooks/useScrcpy.ts
+++ b/src/hooks/useScrcpy.ts
@@ -532,6 +532,19 @@ export function useScrcpy() {
         }
     };
 
+    /** Snaps the running mirror window for `device` back to the centre of the
+     *  primary screen. Recovers a window whose saved position no longer lands
+     *  on any connected monitor (e.g. it was saved on a second monitor that
+     *  has since been unplugged), so it never gets stuck off-screen with no
+     *  way to reach it. */
+    const recenterMirrorWindow = async (device: string) => {
+        try {
+            await invoke('recenter_scrcpy_window', { device });
+        } catch (e) {
+            console.error(e);
+        }
+    };
+
     const downloadScrcpy = async () => {
         try {
             setIsDownloading(true);
@@ -767,6 +780,7 @@ export function useScrcpy() {
         refreshDevicesUntilSettled,
         runScrcpy,
         stopScrcpy,
+        recenterMirrorWindow,
         downloadScrcpy,
         activeDevice,
         setActiveDevice,

--- a/src/hooks/useScrcpy.ts
+++ b/src/hooks/useScrcpy.ts
@@ -69,7 +69,22 @@ export interface ScrcpyConfig {
     backgroundColor?: string;
     keepActive?: boolean;
     vsync?: boolean;
+    /** Whether to remember each device's mirror window position and restore
+     *  it on the next launch. Defaults to true; some users find a window
+     *  that always reopens at scrcpy's default spot less surprising. */
+    rememberWindowPosition?: boolean;
+    /** Screen position (pixels) to restore via --window-x / --window-y for
+     *  this launch. Resolved per-device from windowPositions right before
+     *  invoking run_scrcpy; never set directly by the UI. */
+    windowX?: number;
+    windowY?: number;
 }
+
+/** Last known screen position of the scrcpy window, per device serial. Keyed
+ *  by device because different devices (e.g. a phone vs. a tablet) produce
+ *  very differently sized windows: a single shared position would reopen an
+ *  unrelated device's window mostly off-screen. */
+type WindowPositions = Record<string, { x: number; y: number }>;
 
 export function useScrcpy() {
     const { t } = useI18n();
@@ -124,16 +139,28 @@ export function useScrcpy() {
         cameraZoom: 1.0,
         backgroundColor: '',
         keepActive: false,
-        vsync: true
+        vsync: true,
+        rememberWindowPosition: true
     });
+    const [windowPositions, setWindowPositions] = useState<WindowPositions>({});
     const prevDevicesRef = useRef<string[]>([]);
     const mdnsDevicesRef = useRef<MdnsDevice[]>([]);
+    const rememberWindowPositionRef = useRef(true);
 
     useEffect(() => {
 
         const savedTheme = localStorage.getItem('scrcpy_theme');
         if (savedTheme) {
             setTheme(savedTheme);
+        }
+
+        const savedWindowPositions = localStorage.getItem('scrcpy_window_positions');
+        if (savedWindowPositions) {
+            try {
+                setWindowPositions(JSON.parse(savedWindowPositions));
+            } catch (e) {
+                console.error("Failed to parse saved window positions", e);
+            }
         }
 
         const savedConfig = localStorage.getItem('scrcpy_config');
@@ -183,6 +210,18 @@ export function useScrcpy() {
         if (!isInitialized) return;
         localStorage.setItem('scrcpy_config', JSON.stringify(config));
     }, [config, isInitialized]);
+
+    // Kept in a ref (not read from `config` directly) so the window-position
+    // listener below, which only subscribes once on mount, always sees the
+    // current value without needing to resubscribe on every config change.
+    useEffect(() => {
+        rememberWindowPositionRef.current = config.rememberWindowPosition !== false;
+    }, [config.rememberWindowPosition]);
+
+    useEffect(() => {
+        if (!isInitialized) return;
+        localStorage.setItem('scrcpy_window_positions', JSON.stringify(windowPositions));
+    }, [windowPositions, isInitialized]);
 
     useEffect(() => {
         if (!isInitialized) return;
@@ -251,9 +290,26 @@ export function useScrcpy() {
             }
         });
 
+        // Persist the scrcpy window position emitted when a session ends, so the
+        // next launch restores it (via --window-x / --window-y). This is what
+        // lets a borderless window, which cannot be dragged, reopen where the
+        // user placed it with borders. Keyed by device (not stored on the
+        // shared config): different devices produce very differently sized
+        // windows (e.g. a phone vs. a tablet), so a single shared position
+        // would reopen an unrelated device's window mostly off-screen.
+        const unlistenWindowPos = listen<{ device: string; x: number; y: number }>(
+            'scrcpy-window-pos',
+            (event) => {
+                if (!rememberWindowPositionRef.current) return;
+                const { device, x, y } = event.payload;
+                setWindowPositions(prev => ({ ...prev, [device]: { x, y } }));
+            }
+        );
+
         return () => {
             unlistenLog.then(f => f());
             unlistenStatus.then(f => f());
+            unlistenWindowPos.then(f => f());
         };
     }, [t]);
 
@@ -454,7 +510,15 @@ export function useScrcpy() {
     const runScrcpy = async (config: ScrcpyConfig) => {
         try {
             setLogs(prev => [...prev.slice(-100), t('logs.initializingScrcpy', { device: config.device })]);
-            await invoke('run_scrcpy', { config });
+            // Resolve the saved position for this specific device only, so
+            // launching one device never reuses another device's window spot.
+            const savedPos = config.rememberWindowPosition !== false ? windowPositions[config.device] : undefined;
+            const configWithPos: ScrcpyConfig = {
+                ...config,
+                windowX: savedPos?.x,
+                windowY: savedPos?.y
+            };
+            await invoke('run_scrcpy', { config: configWithPos });
         } catch (e: any) {
             setLogs(prev => [...prev.slice(-100), t('logs.failedToStartScrcpy', { error: String(e) })]);
         }

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -71,6 +71,12 @@ export const ar: Translations = {
         refresh: 'تحديث',
         noDevicesDetected: 'لم يتم اكتشاف أي جهاز',
         discoveredDevices: 'الأجهزة المكتشفة',
+        discoveredHint: 'اضغط على جهاز لإقرانه.',
+        pairModalTitle: 'إقران هذا الجهاز',
+        pairModalNotReadyTitle: 'غير جاهز للإقران بعد',
+        pairModalNotReadyBody: 'هذا الجهاز ليس في شاشة الإقران بعد. على الهاتف، افتح التصحيح اللاسلكي > إقران جهاز برمز الإقران، وسيظهر هنا جاهزًا للإقران.',
+        pairModalWaiting: 'جارٍ التحقق من شاشة الإقران...',
+        pairModalError: 'فشل الإقران. تحقق من الرمز وحاول مرة أخرى.',
         live: 'متصل',
         ready: 'جاهز',
         wifi: 'Wi-Fi',
@@ -89,7 +95,6 @@ export const ar: Translations = {
         wirelessSetupTipWirelessDebugging: 'التصحيح اللاسلكي',
         wirelessSetupTipTextAfter: '.',
         ipConnect: 'الاتصال عبر IP',
-        auto: 'تلقائي',
         ipPlaceholder: '192.168.x.x:5555',
         connect: 'اتصال',
         connecting: '...',
@@ -208,7 +213,9 @@ export const ar: Translations = {
         selectRecordingFolderTitle: 'اختر مجلد التسجيل',
         // v4 features
         keepActive: 'الحفاظ على النشاط',
-        keepActiveTooltip: 'يحاكي نشاط المستخدم لمنع الشاشة من الدخول في وضع السكون (Scrcpy v4+).'
+        keepActiveTooltip: 'يحاكي نشاط المستخدم لمنع الشاشة من الدخول في وضع السكون (Scrcpy v4+).',
+        rememberWindowPosition: 'تذكر موضع النافذة',
+        rememberWindowPositionTooltip: 'إعادة فتح نافذة العرض في نفس المكان الذي وُضعت فيه آخر مرة. عطّل هذا الخيار إذا كنت تغيّر الدقة بشكل متكرر، فقد يفسد الموضع المحفوظ. إذا انتهى بها الأمر خارج الشاشة، اضغط Ctrl+Alt+Shift+C لإعادتها إلى المنتصف.'
     },
     shortcuts: {
         title: 'الاختصارات (Alt +)',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -202,7 +202,7 @@ export const en = {
         fullScreen: 'Full Screen',
         fullScreenTooltip: 'Launch scrcpy in full screen mode.',
         borderless: 'Borderless',
-        borderlessTooltip: 'Launch scrcpy without window borders. Position is remembered between sessions. To move the window: Ctrl+Alt+Shift+W on Windows, Super/Meta+drag on GNOME/KDE.',
+        borderlessTooltip: 'Launch scrcpy without window borders. Position is remembered between sessions. To move the window: Ctrl+Alt+Shift+W on Windows, Super/Meta+drag on GNOME/KDE. If it ever ends up off-screen, press Ctrl+Alt+Shift+C to snap it back to the centre.',
         rememberWindowPosition: 'Remember Window Position',
         rememberWindowPositionTooltip: 'Reopen the mirror window at the same spot it was last placed. Turn this off if you often change resolution -- it can throw off the saved spot. If it ever ends up off-screen, press Ctrl+Alt+Shift+C to snap it back to the centre.',
         recordFeed: 'Record Feed',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -202,7 +202,7 @@ export const en = {
         fullScreen: 'Full Screen',
         fullScreenTooltip: 'Launch scrcpy in full screen mode.',
         borderless: 'Borderless',
-        borderlessTooltip: 'Launch scrcpy without window borders.',
+        borderlessTooltip: 'Launch scrcpy without window borders. Position is remembered between sessions. To move the window: Ctrl+Alt+Shift+W on Windows, Super/Meta+drag on GNOME/KDE.',
         rememberWindowPosition: 'Remember Window Position',
         rememberWindowPositionTooltip: 'Reopen the mirror window at the same spot it was last placed. Turn this off if you often change resolution -- it can throw off the saved spot. If it ever ends up off-screen, press Ctrl+Alt+Shift+C to snap it back to the centre.',
         recordFeed: 'Record Feed',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -203,6 +203,8 @@ export const en = {
         fullScreenTooltip: 'Launch scrcpy in full screen mode.',
         borderless: 'Borderless',
         borderlessTooltip: 'Launch scrcpy without window borders.',
+        rememberWindowPosition: 'Remember Window Position',
+        rememberWindowPositionTooltip: 'Reopen the mirror window at the same spot it was last placed. Turn this off if you often change resolution -- it can throw off the saved spot. If it ever ends up off-screen, press Ctrl+Alt+Shift+C to snap it back to the centre.',
         recordFeed: 'Record Feed',
         recordFeedTooltip: 'Record the screen/camera feed to a file.',
         recordPath: 'Record Path',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -201,7 +201,7 @@ export const fr: Translations = {
         fullScreen: 'Plein Écran',
         fullScreenTooltip: 'Lance scrcpy en mode plein écran.',
         borderless: 'Sans Bordures',
-        borderlessTooltip: 'Lance scrcpy sans bordures de fenêtre. La position est mémorisée entre les sessions. Pour déplacer la fenêtre : Ctrl+Alt+Shift+W sous Windows, Super/Meta+glisser sous GNOME/KDE.',
+        borderlessTooltip: 'Lance scrcpy sans bordures de fenêtre. La position est mémorisée entre les sessions. Pour déplacer la fenêtre : Ctrl+Alt+Shift+W sous Windows, Super/Meta+glisser sous GNOME/KDE. Si jamais elle se retrouve hors de l\'écran, appuyez sur Ctrl+Alt+Shift+C pour la recentrer.',
         rememberWindowPosition: 'Mémoriser la position de la fenêtre',
         rememberWindowPositionTooltip: 'Rouvre la fenêtre de mirroring au même endroit que la dernière fois. Désactivez si vous changez souvent de résolution, ça peut sinon perturber la position enregistrée. Si elle se retrouve hors de l\'écran, appuyez sur Ctrl+Alt+Shift+C pour la recentrer.',
         recordFeed: 'Enregistrer le Flux',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -201,7 +201,7 @@ export const fr: Translations = {
         fullScreen: 'Plein Écran',
         fullScreenTooltip: 'Lance scrcpy en mode plein écran.',
         borderless: 'Sans Bordures',
-        borderlessTooltip: 'Lance scrcpy sans bordures de fenêtre.',
+        borderlessTooltip: 'Lance scrcpy sans bordures de fenêtre. La position est mémorisée entre les sessions. Pour déplacer la fenêtre : Ctrl+Alt+Shift+W sous Windows, Super/Meta+glisser sous GNOME/KDE.',
         rememberWindowPosition: 'Mémoriser la position de la fenêtre',
         rememberWindowPositionTooltip: 'Rouvre la fenêtre de mirroring au même endroit que la dernière fois. Désactivez si vous changez souvent de résolution, ça peut sinon perturber la position enregistrée. Si elle se retrouve hors de l\'écran, appuyez sur Ctrl+Alt+Shift+C pour la recentrer.',
         recordFeed: 'Enregistrer le Flux',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -202,6 +202,8 @@ export const fr: Translations = {
         fullScreenTooltip: 'Lance scrcpy en mode plein écran.',
         borderless: 'Sans Bordures',
         borderlessTooltip: 'Lance scrcpy sans bordures de fenêtre.',
+        rememberWindowPosition: 'Mémoriser la position de la fenêtre',
+        rememberWindowPositionTooltip: 'Rouvre la fenêtre de mirroring au même endroit que la dernière fois. Désactivez si vous changez souvent de résolution, ça peut sinon perturber la position enregistrée. Si elle se retrouve hors de l\'écran, appuyez sur Ctrl+Alt+Shift+C pour la recentrer.',
         recordFeed: 'Enregistrer le Flux',
         recordFeedTooltip: 'Enregistre le flux écran/caméra dans un fichier.',
         recordPath: 'Chemin d\'Enregistrement',

--- a/src/i18n/locales/id.ts
+++ b/src/i18n/locales/id.ts
@@ -202,6 +202,8 @@ languages: {
         fullScreenTooltip: 'Jalankan scrcpy dalam mode layar penuh.',
         borderless: 'Tanpa Border',
         borderlessTooltip: 'Jalankan scrcpy tanpa bingkai jendela.',
+        rememberWindowPosition: 'Ingat Posisi Jendela',
+        rememberWindowPositionTooltip: 'Buka kembali jendela mirroring di posisi terakhir. Nonaktifkan jika Anda sering mengganti resolusi -- ini bisa mengacaukan posisi yang tersimpan. Jika jendela sampai keluar dari layar, tekan Ctrl+Alt+Shift+C untuk mengembalikannya ke tengah.',
         recordFeed: 'Rekam Layar',
         recordFeedTooltip: 'Simpan rekaman layar/kamera langsung ke file.',
         recordPath: 'Jalur Rekaman',

--- a/src/i18n/locales/id.ts
+++ b/src/i18n/locales/id.ts
@@ -201,7 +201,7 @@ languages: {
         fullScreen: 'Layar Penuh',
         fullScreenTooltip: 'Jalankan scrcpy dalam mode layar penuh.',
         borderless: 'Tanpa Border',
-        borderlessTooltip: 'Jalankan scrcpy tanpa bingkai jendela. Posisi diingat antar sesi. Untuk memindahkan jendela: Ctrl+Alt+Shift+W di Windows, Super/Meta+seret di GNOME/KDE.',
+        borderlessTooltip: 'Jalankan scrcpy tanpa bingkai jendela. Posisi diingat antar sesi. Untuk memindahkan jendela: Ctrl+Alt+Shift+W di Windows, Super/Meta+seret di GNOME/KDE. Jika jendela sampai keluar dari layar, tekan Ctrl+Alt+Shift+C untuk mengembalikannya ke tengah.',
         rememberWindowPosition: 'Ingat Posisi Jendela',
         rememberWindowPositionTooltip: 'Buka kembali jendela mirroring di posisi terakhir. Nonaktifkan jika Anda sering mengganti resolusi -- ini bisa mengacaukan posisi yang tersimpan. Jika jendela sampai keluar dari layar, tekan Ctrl+Alt+Shift+C untuk mengembalikannya ke tengah.',
         recordFeed: 'Rekam Layar',

--- a/src/i18n/locales/id.ts
+++ b/src/i18n/locales/id.ts
@@ -201,7 +201,7 @@ languages: {
         fullScreen: 'Layar Penuh',
         fullScreenTooltip: 'Jalankan scrcpy dalam mode layar penuh.',
         borderless: 'Tanpa Border',
-        borderlessTooltip: 'Jalankan scrcpy tanpa bingkai jendela.',
+        borderlessTooltip: 'Jalankan scrcpy tanpa bingkai jendela. Posisi diingat antar sesi. Untuk memindahkan jendela: Ctrl+Alt+Shift+W di Windows, Super/Meta+seret di GNOME/KDE.',
         rememberWindowPosition: 'Ingat Posisi Jendela',
         rememberWindowPositionTooltip: 'Buka kembali jendela mirroring di posisi terakhir. Nonaktifkan jika Anda sering mengganti resolusi -- ini bisa mengacaukan posisi yang tersimpan. Jika jendela sampai keluar dari layar, tekan Ctrl+Alt+Shift+C untuk mengembalikannya ke tengah.',
         recordFeed: 'Rekam Layar',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -201,7 +201,7 @@ export const ptBR: Translations = {
         fullScreen: 'Tela Cheia',
         fullScreenTooltip: 'Inicia o scrcpy em modo de tela cheia.',
         borderless: 'Sem Bordas',
-        borderlessTooltip: 'Inicia o scrcpy sem bordas de janela.',
+        borderlessTooltip: 'Inicia o scrcpy sem bordas de janela. A posição é lembrada entre sessões. Para mover a janela: Ctrl+Alt+Shift+W no Windows, Super/Meta+arrastar no GNOME/KDE.',
         rememberWindowPosition: 'Lembrar Posição da Janela',
         rememberWindowPositionTooltip: 'Reabre a janela de espelhamento no mesmo lugar em que estava. Desative se você muda de resolução com frequência -- isso pode bagunçar a posição salva. Se ela sair da tela, pressione Ctrl+Alt+Shift+C para recentralizá-la.',
         recordFeed: 'Gravar Transmissão',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -202,6 +202,8 @@ export const ptBR: Translations = {
         fullScreenTooltip: 'Inicia o scrcpy em modo de tela cheia.',
         borderless: 'Sem Bordas',
         borderlessTooltip: 'Inicia o scrcpy sem bordas de janela.',
+        rememberWindowPosition: 'Lembrar Posição da Janela',
+        rememberWindowPositionTooltip: 'Reabre a janela de espelhamento no mesmo lugar em que estava. Desative se você muda de resolução com frequência -- isso pode bagunçar a posição salva. Se ela sair da tela, pressione Ctrl+Alt+Shift+C para recentralizá-la.',
         recordFeed: 'Gravar Transmissão',
         recordFeedTooltip: 'Grava a transmissão da tela/câmera em um arquivo.',
         recordPath: 'Caminho de Gravação',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -201,7 +201,7 @@ export const ptBR: Translations = {
         fullScreen: 'Tela Cheia',
         fullScreenTooltip: 'Inicia o scrcpy em modo de tela cheia.',
         borderless: 'Sem Bordas',
-        borderlessTooltip: 'Inicia o scrcpy sem bordas de janela. A posição é lembrada entre sessões. Para mover a janela: Ctrl+Alt+Shift+W no Windows, Super/Meta+arrastar no GNOME/KDE.',
+        borderlessTooltip: 'Inicia o scrcpy sem bordas de janela. A posição é lembrada entre sessões. Para mover a janela: Ctrl+Alt+Shift+W no Windows, Super/Meta+arrastar no GNOME/KDE. Se ela sair da tela, pressione Ctrl+Alt+Shift+C para recentralizá-la.',
         rememberWindowPosition: 'Lembrar Posição da Janela',
         rememberWindowPositionTooltip: 'Reabre a janela de espelhamento no mesmo lugar em que estava. Desative se você muda de resolução com frequência -- isso pode bagunçar a posição salva. Se ela sair da tela, pressione Ctrl+Alt+Shift+C para recentralizá-la.',
         recordFeed: 'Gravar Transmissão',

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -207,7 +207,7 @@ export const ru: Translations = {
     fullScreen: 'Полный экран',
     fullScreenTooltip: 'Запускать scrcpy в полноэкранном режиме.',
     borderless: 'Без рамок',
-    borderlessTooltip: 'Запускать scrcpy без рамки окна. Позиция запоминается между сессиями. Чтобы переместить окно: Ctrl+Alt+Shift+W в Windows, Super/Meta+перетаскивание в GNOME/KDE.',
+    borderlessTooltip: 'Запускать scrcpy без рамки окна. Позиция запоминается между сессиями. Чтобы переместить окно: Ctrl+Alt+Shift+W в Windows, Super/Meta+перетаскивание в GNOME/KDE. Если окно окажется за пределами экрана, нажмите Ctrl+Alt+Shift+C, чтобы вернуть его по центру.',
     rememberWindowPosition: 'Запоминать позицию окна',
     rememberWindowPositionTooltip: 'Открывать окно трансляции там же, где оно было в прошлый раз. Отключите, если вы часто меняете разрешение -- это может сбить сохранённую позицию. Если окно окажется за пределами экрана, нажмите Ctrl+Alt+Shift+C, чтобы вернуть его по центру.',
     recordFeed: 'Записывать поток',

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -208,6 +208,8 @@ export const ru: Translations = {
     fullScreenTooltip: 'Запускать scrcpy в полноэкранном режиме.',
     borderless: 'Без рамок',
     borderlessTooltip: 'Запускать scrcpy без рамки окна.',
+    rememberWindowPosition: 'Запоминать позицию окна',
+    rememberWindowPositionTooltip: 'Открывать окно трансляции там же, где оно было в прошлый раз. Отключите, если вы часто меняете разрешение -- это может сбить сохранённую позицию. Если окно окажется за пределами экрана, нажмите Ctrl+Alt+Shift+C, чтобы вернуть его по центру.',
     recordFeed: 'Записывать поток',
     recordFeedTooltip: 'Записывать экран/камеру в файл.',
     recordPath: 'Путь записи',

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -207,7 +207,7 @@ export const ru: Translations = {
     fullScreen: 'Полный экран',
     fullScreenTooltip: 'Запускать scrcpy в полноэкранном режиме.',
     borderless: 'Без рамок',
-    borderlessTooltip: 'Запускать scrcpy без рамки окна.',
+    borderlessTooltip: 'Запускать scrcpy без рамки окна. Позиция запоминается между сессиями. Чтобы переместить окно: Ctrl+Alt+Shift+W в Windows, Super/Meta+перетаскивание в GNOME/KDE.',
     rememberWindowPosition: 'Запоминать позицию окна',
     rememberWindowPositionTooltip: 'Открывать окно трансляции там же, где оно было в прошлый раз. Отключите, если вы часто меняете разрешение -- это может сбить сохранённую позицию. Если окно окажется за пределами экрана, нажмите Ctrl+Alt+Shift+C, чтобы вернуть его по центру.',
     recordFeed: 'Записывать поток',
@@ -291,7 +291,7 @@ export const ru: Translations = {
     noDeviceSelectedTitle: 'Устройство не выбрано',
     noDeviceSelectedMessage: 'Выберите устройство на боковой панели, чтобы продолжить.\nПодсказка: если вы только что подключили телефон, нажмите «Обновить» на боковой панели, чтобы обновить список.',
     updateAvailableTitle: 'Доступно обновление',
-    updateAvailableMessage: 'Доступна новая версия Scrcpy (v{latest}). Ваша установленная версия — v{local}. Хотите обновить сейчас?',
+    updateAvailableMessage: 'Доступна новая версия Scrcpy (v{latest}). Ваша установленная версия, v{local}. Хотите обновить сейчас?',
     updateBtn: 'Обновить сейчас',
     cancelBtn: 'Позже'
   },

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -201,7 +201,7 @@ export const zhCN: Translations = {
         fullScreen: '全屏',
         fullScreenTooltip: '以全屏模式启动 scrcpy。',
         borderless: '无边框',
-        borderlessTooltip: '启动 scrcpy 时不显示窗口边框。窗口位置会在会话间记住。移动窗口：Windows 上按 Ctrl+Alt+Shift+W，GNOME/KDE 上用 Super/Meta+拖动。',
+        borderlessTooltip: '启动 scrcpy 时不显示窗口边框。窗口位置会在会话间记住。移动窗口：Windows 上按 Ctrl+Alt+Shift+W，GNOME/KDE 上用 Super/Meta+拖动。如果窗口跑到屏幕外，按 Ctrl+Alt+Shift+C 可将其重新居中。',
         rememberWindowPosition: '记住窗口位置',
         rememberWindowPositionTooltip: '在上次的位置重新打开镜像窗口。如果你经常切换分辨率，建议关闭此项，否则可能打乱已保存的位置。如果窗口跑到屏幕外，按 Ctrl+Alt+Shift+C 可将其重新居中。',
         recordFeed: '录制画面',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -202,6 +202,8 @@ export const zhCN: Translations = {
         fullScreenTooltip: '以全屏模式启动 scrcpy。',
         borderless: '无边框',
         borderlessTooltip: '启动 scrcpy 时不显示窗口边框。',
+        rememberWindowPosition: '记住窗口位置',
+        rememberWindowPositionTooltip: '在上次的位置重新打开镜像窗口。如果你经常切换分辨率，建议关闭此项，否则可能打乱已保存的位置。如果窗口跑到屏幕外，按 Ctrl+Alt+Shift+C 可将其重新居中。',
         recordFeed: '录制画面',
         recordFeedTooltip: '将屏幕或摄像头画面录制到文件。',
         recordPath: '录制路径',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -201,7 +201,7 @@ export const zhCN: Translations = {
         fullScreen: '全屏',
         fullScreenTooltip: '以全屏模式启动 scrcpy。',
         borderless: '无边框',
-        borderlessTooltip: '启动 scrcpy 时不显示窗口边框。',
+        borderlessTooltip: '启动 scrcpy 时不显示窗口边框。窗口位置会在会话间记住。移动窗口：Windows 上按 Ctrl+Alt+Shift+W，GNOME/KDE 上用 Super/Meta+拖动。',
         rememberWindowPosition: '记住窗口位置',
         rememberWindowPositionTooltip: '在上次的位置重新打开镜像窗口。如果你经常切换分辨率，建议关闭此项，否则可能打乱已保存的位置。如果窗口跑到屏幕外，按 Ctrl+Alt+Shift+C 可将其重新居中。',
         recordFeed: '录制画面',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -201,7 +201,7 @@ export const zhTW: Translations = {
         fullScreen: '全螢幕',
         fullScreenTooltip: '以全螢幕啟動。',
         borderless: '無邊框',
-        borderlessTooltip: '無視窗邊框模式。視窗位置會在工作階段之間記住。移動視窗：Windows 上按 Ctrl+Alt+Shift+W，GNOME/KDE 上用 Super/Meta+拖曳。',
+        borderlessTooltip: '無視窗邊框模式。視窗位置會在工作階段之間記住。移動視窗：Windows 上按 Ctrl+Alt+Shift+W，GNOME/KDE 上用 Super/Meta+拖曳。如果視窗跑到螢幕外，按 Ctrl+Alt+Shift+C 可將其重新置中。',
         rememberWindowPosition: '記住視窗位置',
         rememberWindowPositionTooltip: '在上次的位置重新開啟鏡像視窗。如果你經常切換解析度，建議關閉此項，否則可能打亂已儲存的位置。如果視窗跑到螢幕外，按 Ctrl+Alt+Shift+C 可將其重新置中。',
         recordFeed: '錄影',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -202,6 +202,8 @@ export const zhTW: Translations = {
         fullScreenTooltip: '以全螢幕啟動。',
         borderless: '無邊框',
         borderlessTooltip: '無視窗邊框模式。',
+        rememberWindowPosition: '記住視窗位置',
+        rememberWindowPositionTooltip: '在上次的位置重新開啟鏡像視窗。如果你經常切換解析度，建議關閉此項，否則可能打亂已儲存的位置。如果視窗跑到螢幕外，按 Ctrl+Alt+Shift+C 可將其重新置中。',
         recordFeed: '錄影',
         recordFeedTooltip: '錄製畫面。',
         recordPath: '錄影路徑',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -201,7 +201,7 @@ export const zhTW: Translations = {
         fullScreen: '全螢幕',
         fullScreenTooltip: '以全螢幕啟動。',
         borderless: '無邊框',
-        borderlessTooltip: '無視窗邊框模式。',
+        borderlessTooltip: '無視窗邊框模式。視窗位置會在工作階段之間記住。移動視窗：Windows 上按 Ctrl+Alt+Shift+W，GNOME/KDE 上用 Super/Meta+拖曳。',
         rememberWindowPosition: '記住視窗位置',
         rememberWindowPositionTooltip: '在上次的位置重新開啟鏡像視窗。如果你經常切換解析度，建議關閉此項，否則可能打亂已儲存的位置。如果視窗跑到螢幕外，按 Ctrl+Alt+Shift+C 可將其重新置中。',
         recordFeed: '錄影',


### PR DESCRIPTION
## 🐛 The problem
The mirror window always reopened at scrcpy's default position. Moving it, closing, then relaunching lost the placement every time. That's annoying on its own, but with Borderless enabled it becomes a real dead end: no title bar means no drag handle, so once the window landed somewhere inconvenient, or off screen (for example a position saved while a second monitor was attached, then unplugged), there was no way to get it back short of disabling Borderless, moving it, then re-enabling.

## 🎯 What this does
- Remembers and restores the mirror window's position across sessions (on by default, toggle in Session Behavior): it reopens exactly where you left it instead of at scrcpy's default spot.
- Ctrl+Alt+Shift+W (Windows only): grab and drag a borderless window with the mouse, since it has no title bar to drag from. Drop it with a click, or press the shortcut again.
- Ctrl+Alt+Shift+C (cross-platform): snap an off screen mirror window back to the centre of the screen, so a window you can't see or reach anymore isn't lost for good.

## 🧪 Tested
- [x] Moved the mirror window, closed it right away, relaunched: reopens at the exact same spot.
- [x] Tested on 2 different PCs: one on a single 1080p screen, and one on a dual 4K monitor setup. Very important since it also works correctly when the mirror is placed on the second screen, not just the primary one.
- [x] Borderless: Ctrl+Alt+Shift+W drags the window, Ctrl+Alt+Shift+C recentres it after dragging it off screen.
- [x] npm run build
- [x] npm run tauri dev

## 📸 Screenshots
<img width="901" height="817" alt="image" src="https://github.com/user-attachments/assets/81c70569-06e1-4a1c-95a1-55115d557f1c" />

## 🐛 Also fixed: the release build is broken on upstream main
While testing the release build, `npm run build` fails unconditionally on the current upstream main: the Arabic locale (`ar.ts`, added in #113) has a stray key and is missing 8 keys the other locales already have, so `tsc` fails and `npm run tauri build` never completes. This has nothing to do with this PR specifically, it blocks the release build for literally any branch based on main right now. Included a dedicated commit fixing it so this PR isn't stuck behind an unrelated, already-broken build.