### PR TITLE
✨feat: show a friendly device name in the hub instead of the raw serial

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -205,6 +205,22 @@ fn parse_adb_device_line(line: &str) -> Option<(String, String)> {
     Some((tokens[..state_idx].join(" "), tokens[state_idx].to_string()))
 }
 
+/// Extracts the `model:` field from a `adb devices -l` line, if present, for
+/// a more user-friendly device label than the raw serial (e.g. "SM S911B"
+/// instead of a USB serial or IP:port). Adb replaces spaces in the model name
+/// with underscores in this raw form; those are turned back into spaces,
+/// which is as far as this goes without an extra `getprop` round-trip per
+/// device -- still closer to a real name than a serial.
+fn extract_device_model(line: &str) -> Option<String> {
+    let model = line
+        .split_whitespace()
+        .find_map(|t| t.strip_prefix("model:"))?;
+    if model.is_empty() {
+        return None;
+    }
+    Some(model.replace('_', " "))
+}
+
 #[tauri::command]
 pub async fn get_devices(custom_path: Option<String>) -> serde_json::Value {
     let adb_path = get_binary_path("adb", custom_path);
@@ -219,14 +235,21 @@ pub async fn get_devices(custom_path: Option<String>) -> serde_json::Value {
         Ok(o) => {
              if o.status.success() {
                  let out_str = String::from_utf8_lossy(&o.stdout);
-                 let devices: Vec<String> = out_str.lines()
-                    .skip(1) // Skip "List of devices attached"
-                    .filter_map(parse_adb_device_line)
-                    .filter(|(_, state)| state == "device")
-                    .map(|(serial, _)| serial)
-                    .collect();
+                 let mut devices: Vec<String> = Vec::new();
+                 let mut device_models = serde_json::Map::new();
+                 for line in out_str.lines().skip(1) {
+                     // Skip "List of devices attached"
+                     let Some((serial, state)) = parse_adb_device_line(line) else { continue };
+                     if state != "device" {
+                         continue;
+                     }
+                     if let Some(model) = extract_device_model(line) {
+                         device_models.insert(serial.clone(), json!(model));
+                     }
+                     devices.push(serial);
+                 }
 
-                 json!({ "error": false, "devices": devices })
+                 json!({ "error": false, "devices": devices, "deviceModels": device_models })
              } else {
                  json!({ "error": true, "message": "ADB returned error" })
              }
@@ -1900,6 +1923,21 @@ mod tests {
             ),
             Some(("ZY22MGW35T".to_string(), "device".to_string()))
         );
+    }
+
+    #[test]
+    fn test_extract_device_model_replaces_underscores_with_spaces() {
+        assert_eq!(
+            extract_device_model(
+                "ZY22MGW35T device usb:1-1 product:foo model:SM_S911B device:baz transport_id:1"
+            ),
+            Some("SM S911B".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_device_model_missing_field_returns_none() {
+        assert_eq!(extract_device_model("ZY22MGW35T device"), None);
     }
 
     #[test]

--- a/src-tauri/src/grab.rs
+++ b/src-tauri/src/grab.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use tauri::{AppHandle, Manager, Runtime};
-use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut};
+use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut};
 
 use windows::Win32::Foundation::{HINSTANCE, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM};
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,8 @@ function App() {
   const { t } = useI18n();
   const {
     devices,
+    deviceModels,
+    deviceFriendlyNames,
     logs,
     activeDevice,
     setActiveDevice,
@@ -334,6 +336,8 @@ function App() {
                 <div className="transition-all duration-700">
                   <Sidebar
                     devices={devices}
+                    deviceModels={deviceModels}
+                    deviceFriendlyNames={deviceFriendlyNames}
                     runningDevices={runningDevices}
                     onRefresh={handleRefresh}
                     onKillAdb={handleKillAdb}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -22,6 +22,12 @@ function formatMdnsName(name: string): string {
 
 export interface SidebarProps {
     devices: string[];
+    // Best-effort, display-only device model per serial; falls back to
+    // formatDeviceLabel(d) when a serial has no known model yet.
+    deviceModels?: Record<string, string>;
+    // Nicer marketing name per serial when available (e.g. "Galaxy S23"),
+    // fetched lazily; preferred over deviceModels when present.
+    deviceFriendlyNames?: Record<string, string>;
     runningDevices: string[];
     onRefresh: () => void;
     onKillAdb: () => void;
@@ -39,6 +45,8 @@ export interface SidebarProps {
 
 export default function Sidebar({
     devices,
+    deviceModels = {},
+    deviceFriendlyNames = {},
     runningDevices,
     onRefresh,
     onKillAdb,
@@ -177,7 +185,7 @@ export default function Sidebar({
                                             <Smartphone size={14} />
                                         </div>
                                         <div className="flex-1 min-w-0">
-                                            <p className={`text-[11px] font-bold truncate tracking-tight ${isSelected ? 'text-white' : 'text-zinc-400 group-hover:text-zinc-200'}`}>{formatDeviceLabel(d)}</p>
+                                            <p className={`text-[11px] font-bold truncate tracking-tight ${isSelected ? 'text-white' : 'text-zinc-400 group-hover:text-zinc-200'}`}>{deviceFriendlyNames[d] || deviceModels[d] || formatDeviceLabel(d)}</p>
                                             <div className="flex items-center gap-2 mt-0.5">
                                                 {isRunning ? (
                                                     <span className="flex items-center gap-1">

--- a/src/hooks/useScrcpy.ts
+++ b/src/hooks/useScrcpy.ts
@@ -89,6 +89,15 @@ type WindowPositions = Record<string, { x: number; y: number }>;
 export function useScrcpy() {
     const { t } = useI18n();
     const [devices, setDevices] = useState<string[]>([]);
+    // Best-effort, display-only device model per serial (from `adb devices
+    // -l`'s own `model:` field). Never used for identity/comparisons -- `d`
+    // (the serial) remains the source of truth everywhere else.
+    const [deviceModels, setDeviceModels] = useState<Record<string, string>>({});
+    // Nicer than deviceModels when available (e.g. "Galaxy S23" instead of
+    // "SM S911B"), fetched lazily per device via one extra `adb shell
+    // getprop` round-trip -- see the effect below for the once-per-serial
+    // cache that keeps this off the 5s background device poll.
+    const [deviceFriendlyNames, setDeviceFriendlyNames] = useState<Record<string, string>>({});
     const [logs, setLogs] = useState<string[]>([]);
     const [activeDevice, setActiveDevice] = useState<string>("");
     const [status, setStatus] = useState<string>("");
@@ -146,6 +155,11 @@ export function useScrcpy() {
     const prevDevicesRef = useRef<string[]>([]);
     const mdnsDevicesRef = useRef<MdnsDevice[]>([]);
     const rememberWindowPositionRef = useRef(true);
+    // Serials already queried for a friendly name this session (success or
+    // failure) -- guards against re-querying the same device on every 5s
+    // background poll. A failed attempt is not retried until the app restarts;
+    // the display falls back to deviceModels/the serial in the meantime.
+    const fetchedFriendlyNamesRef = useRef<Set<string>>(new Set());
 
     useEffect(() => {
 
@@ -353,6 +367,9 @@ export function useScrcpy() {
 
             if (!res.error) {
                 newDevices = res.devices as string[];
+                if (res.deviceModels) {
+                    setDeviceModels(res.deviceModels as Record<string, string>);
+                }
                 const prevDevices = prevDevicesRef.current;
 
                 // Identify connections/disconnections
@@ -479,6 +496,69 @@ export function useScrcpy() {
         }, 5000);
         return () => clearInterval(interval);
     }, []);
+
+    // Upgrade each device's label to its marketing name (e.g. "Galaxy S23"),
+    // one extra `adb shell getprop` round-trip per *newly seen* serial only --
+    // fetchedFriendlyNamesRef is what keeps this off the 5s poll above, since
+    // `devices` is a new array reference on every poll tick even when its
+    // contents haven't changed.
+    useEffect(() => {
+        devices.forEach(async (serial) => {
+            if (fetchedFriendlyNamesRef.current.has(serial)) return;
+            fetchedFriendlyNamesRef.current.add(serial);
+
+            // Emulators (Android Studio AVDs, "emulator-5554") never have a
+            // meaningful marketname or manufacturer, and ro.product.model is
+            // a generic SDK build string (e.g. "sdk_gphone64_x86_64") --
+            // uglier than the plain serial adb already assigns. Look up the
+            // AVD's own configured name instead; if that's unavailable too,
+            // explicitly keep the serial so it doesn't fall through to that
+            // uglier model string via deviceModels.
+            const isEmulator = /^emulator-\d+$/.test(serial);
+
+            try {
+                const command = isEmulator
+                    ? 'getprop ro.boot.qemu.avd_name; getprop ro.kernel.qemu.avd_name'
+                    : 'getprop ro.product.marketname; getprop ro.product.manufacturer; getprop ro.product.model';
+                const res: any = await invoke('adb_shell', { device: serial, command, customPath: config.scrcpyPath });
+
+                if (isEmulator) {
+                    const avdName = res?.success
+                        ? (res.output as string).split('\n').map(line => line.trim()).find(line => line.length > 0)
+                        : undefined;
+                    // Keep the serial visible alongside the AVD name: several
+                    // emulator instances of the same AVD image running at
+                    // once would otherwise show up as indistinguishable
+                    // identical labels in the hub.
+                    setDeviceFriendlyNames(prev => ({
+                        ...prev,
+                        [serial]: avdName ? `${avdName.replace(/_/g, ' ')} (${serial})` : serial
+                    }));
+                    return;
+                }
+
+                if (res?.success) {
+                    const [marketname, manufacturer, model] = (res.output as string)
+                        .split('\n')
+                        .map(line => line.trim());
+                    // Most devices never set marketname (it's not a universal
+                    // property -- scrcpy's own device log falls back to the
+                    // same manufacturer+model combo for exactly this reason,
+                    // e.g. "[OPPO] OPPO CPH2697"). Avoid a doubled-up name
+                    // when the model already starts with the manufacturer.
+                    const name = marketname ||
+                        (manufacturer && model && !model.toLowerCase().startsWith(manufacturer.toLowerCase())
+                            ? `${manufacturer} ${model}`
+                            : model);
+                    if (name) {
+                        setDeviceFriendlyNames(prev => ({ ...prev, [serial]: name }));
+                    }
+                }
+            } catch (e) {
+                console.error("Failed to fetch friendly name for", serial, e);
+            }
+        });
+    }, [devices, config.scrcpyPath]);
 
     // Legacy ADB-over-network devices (a plain ip:port from the manual "IP
     // Connect" field, e.g. an Android TV/set-top box on `adb tcpip`) have no
@@ -770,6 +850,8 @@ export function useScrcpy() {
 
     return {
         devices,
+        deviceModels,
+        deviceFriendlyNames,
         logs,
         setLogs,
         clearLogs,


### PR DESCRIPTION
## 🐛 The problem
The device hub showed the raw ADB serial (or an IP:port), not very readable, especially with several devices connected at the same time.

## 🎯 What this does
- Uses the `model` field already returned by `adb devices -l` as a first improvement, no extra call needed.
- Fetches a nicer name (marketing name, or manufacturer + model) via one extra `getprop` call per device, cached so it never re-fires on the 5s background refresh.
- Special case for emulators: shows the AVD name configured in Android Studio followed by the serial in parentheses, so multiple instances of the same emulator stay distinguishable.
- If none of that is available, it falls back to the serial like before, never an empty or broken display.

## 🧹 While I was at it
Small cleanup included: an unused import in `grab.rs` that was triggering a compiler warning on Windows.

## 📸 Screenshots

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/ff3ebea7-99b0-4038-b16e-c828802a3ca8) | ![after](https://github.com/user-attachments/assets/c13afbb9-bf59-4eed-983a-6be0d628444e) |

## 🧪 Tested
- [x] Tested with 2 real Android phones, the marketing name is fetched correctly
- [x] Tested with an Android Studio emulator, the AVD name and serial display correctly
- [x] Verified the name doesn't get re-fetched on every background refresh
- [x] `npm run tauri dev`
- [x] `npm run tauri build`