### PR TITLE
feat: Add scrcpy v4.1 compatibility (VP8/VP9 video codecs & encoder constraint toggle)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -751,6 +751,11 @@ pub struct ScrcpyConfig {
     /// the user left it, including when relaunching borderless.
     window_x: Option<i32>,
     window_y: Option<i32>,
+    // v4.1 features
+    /// Ignore video encoder size constraints entirely (scrcpy v4.1+).
+    /// Useful when the device reports incorrect encoder limits that prevent
+    /// scrcpy from starting.
+    ignore_video_encoder_constraints: Option<bool>,
 }
 
 fn resolve_audio_codec_flag<'a>(config: &'a ScrcpyConfig, audio_codec_override: Option<&'a str>) -> Option<&'a str> {
@@ -1281,6 +1286,11 @@ fn build_scrcpy_args(config: &ScrcpyConfig, video_dir_fallback: Option<String>, 
             if !trimmed.is_empty() {
                 args.push(format!("--background-color={}", trimmed));
             }
+        }
+
+        // v4.1: ignore video encoder size constraints
+        if let Some(true) = config.ignore_video_encoder_constraints {
+            args.push("--ignore-video-encoder-constraints".to_string());
         }
     }
     

--- a/src/components/ControlPanel/ControlPanel.tsx
+++ b/src/components/ControlPanel/ControlPanel.tsx
@@ -163,6 +163,8 @@ export default function ControlPanel({
                         { value: "h264", label: "H.264" },
                         { value: "h265", label: "H.265" },
                         { value: "av1", label: "AV1" },
+                        { value: "vp8", label: "VP8" },
+                        { value: "vp9", label: "VP9" },
                     ]}
                 />
             )}
@@ -208,6 +210,21 @@ export default function ControlPanel({
                     <span className="text-[10px] font-bold uppercase text-zinc-300 tracking-wide group-hover:text-primary transition-colors">{t('controlPanel.vsync')}</span>
                 </div>
                 <span className="text-[8px] font-black uppercase tracking-tighter text-zinc-600 group-hover:text-primary/70 transition-colors">{t('controlPanel.vsyncHint')}</span>
+            </div>
+        </Tooltip>
+        {/* v4.1: ignore encoder constraints */}
+        <Tooltip text={t('controlPanel.ignoreEncoderConstraintsTooltip')}>
+            <div
+                className="flex items-center justify-between gap-2 cursor-pointer group px-2 py-1.5 rounded-lg border border-zinc-800/60 bg-zinc-950/20 hover:border-primary/40 transition-colors"
+                onClick={() => handleChange('ignoreVideoEncoderConstraints', !config.ignoreVideoEncoderConstraints)}
+            >
+                <div className="flex items-center gap-2">
+                    <div className={`w-3.5 h-3.5 rounded border flex items-center justify-center transition-colors ${config.ignoreVideoEncoderConstraints ? 'bg-primary border-primary' : 'border-zinc-700 group-hover:border-primary'}`}>
+                        {config.ignoreVideoEncoderConstraints && <div className="w-1.5 h-1.5 bg-black rounded-[1px]" />}
+                    </div>
+                    <span className="text-[10px] font-bold uppercase text-zinc-300 tracking-wide group-hover:text-primary transition-colors">{t('controlPanel.ignoreEncoderConstraints')}</span>
+                </div>
+                <span className="text-[8px] font-black uppercase tracking-tighter text-zinc-600 group-hover:text-primary/70 transition-colors">v4.1</span>
             </div>
         </Tooltip>
         </>
@@ -391,6 +408,8 @@ export default function ControlPanel({
                                         { value: "h264", label: "H.264" },
                                         { value: "h265", label: "H.265" },
                                         { value: "av1", label: "AV1" },
+                                        { value: "vp8", label: "VP8" },
+                                        { value: "vp9", label: "VP9" },
                                     ]}
                                 />
                                 <CustomSelect

--- a/src/hooks/useScrcpy.ts
+++ b/src/hooks/useScrcpy.ts
@@ -73,6 +73,10 @@ export interface ScrcpyConfig {
      *  it on the next launch. Defaults to true; some users find a window
      *  that always reopens at scrcpy's default spot less surprising. */
     rememberWindowPosition?: boolean;
+    // v4.1 features
+    /** Ignore video encoder size constraints (--ignore-video-encoder-constraints).
+     *  Useful for devices that report incorrect encoder limits (scrcpy v4.1+). */
+    ignoreVideoEncoderConstraints?: boolean;
     /** Screen position (pixels) to restore via --window-x / --window-y for
      *  this launch. Resolved per-device from windowPositions right before
      *  invoking run_scrcpy; never set directly by the UI. */
@@ -149,7 +153,9 @@ export function useScrcpy() {
         backgroundColor: '',
         keepActive: false,
         vsync: true,
-        rememberWindowPosition: true
+        rememberWindowPosition: true,
+        // v4.1 features
+        ignoreVideoEncoderConstraints: false,
     });
     const [windowPositions, setWindowPositions] = useState<WindowPositions>({});
     const prevDevicesRef = useRef<string[]>([]);

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -182,7 +182,10 @@ export const ar: Translations = {
         backgroundColor: 'لون الخلفية',
         backgroundColorTooltip: 'لون الخلفية بصيغة Hex (مثل ‎#1a1a1a). اتركه فارغًا لاستخدام اللون الرمادي الداكن الافتراضي (Scrcpy v4+).',
         backgroundColorNone: 'الافتراضي',
-        badgeNew: 'جديد'
+        badgeNew: 'جديد',
+        // v4.1 features
+        ignoreEncoderConstraints: 'Ignore Encoder Constraints',
+        ignoreEncoderConstraintsTooltip: 'Skip video encoder size constraints entirely. Use this if scrcpy fails to start or has resolution issues due to the device reporting incorrect encoder limits (scrcpy v4.1+).'
     },
     sessionBehavior: {
         title: 'سلوك الجلسة',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -180,7 +180,10 @@ export const en = {
         backgroundColor: 'BG Color',
         backgroundColorTooltip: 'Hex color for the window background/letterbox area (e.g. #1a1a1a). Leave blank for default dark gray. (scrcpy v4+)',
         backgroundColorNone: 'Default',
-        badgeNew: 'NEW'
+        badgeNew: 'NEW',
+        // v4.1 features
+        ignoreEncoderConstraints: 'Ignore Encoder Constraints',
+        ignoreEncoderConstraintsTooltip: 'Skip video encoder size constraints entirely. Use this if scrcpy fails to start or has resolution issues due to the device reporting incorrect encoder limits (scrcpy v4.1+).',
     },
     sessionBehavior: {
         title: 'Session Behavior',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -179,7 +179,10 @@ export const fr: Translations = {
         backgroundColor: 'Couleur Fond',
         backgroundColorTooltip: 'Couleur hex pour le fond/letterbox de la fenêtre (ex. #1a1a1a). Laisser vide pour gris foncé par défaut. (scrcpy v4+)',
         backgroundColorNone: 'Défaut',
-        badgeNew: 'NOUVEAU'
+        badgeNew: 'NOUVEAU',
+        // v4.1 features
+        ignoreEncoderConstraints: 'Ignore Encoder Constraints',
+        ignoreEncoderConstraintsTooltip: 'Skip video encoder size constraints entirely. Use this if scrcpy fails to start or has resolution issues due to the device reporting incorrect encoder limits (scrcpy v4.1+).',
     },
     sessionBehavior: {
         title: 'Comportement de la Session',

--- a/src/i18n/locales/id.ts
+++ b/src/i18n/locales/id.ts
@@ -179,7 +179,10 @@ languages: {
         backgroundColor: 'Warna BG',
         backgroundColorTooltip: 'Warna hex untuk latar belakang jendela/area letterbox (mis. #1a1a1a). Kosongkan untuk abu-abu gelap bawaan. (scrcpy v4+)',
         backgroundColorNone: 'Bawaan',
-        badgeNew: 'BARU'
+        badgeNew: 'BARU',
+        // v4.1 features
+        ignoreEncoderConstraints: 'Ignore Encoder Constraints',
+        ignoreEncoderConstraintsTooltip: 'Skip video encoder size constraints entirely. Use this if scrcpy fails to start or has resolution issues due to the device reporting incorrect encoder limits (scrcpy v4.1+).',
     },
     sessionBehavior: {
         title: 'Pengaturan Sesi',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -179,7 +179,10 @@ export const ptBR: Translations = {
         backgroundColor: 'Cor do Fundo',
         backgroundColorTooltip: 'Cor hex para o fundo/letterbox da janela (ex. #1a1a1a). Deixe vazio para cinza escuro padrão. (scrcpy v4+)',
         backgroundColorNone: 'Padrão',
-        badgeNew: 'NOVO'
+        badgeNew: 'NOVO',
+        // v4.1 features
+        ignoreEncoderConstraints: 'Ignore Encoder Constraints',
+        ignoreEncoderConstraintsTooltip: 'Skip video encoder size constraints entirely. Use this if scrcpy fails to start or has resolution issues due to the device reporting incorrect encoder limits (scrcpy v4.1+).',
     },
     sessionBehavior: {
         title: 'Comportamento da Sessão',

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -184,7 +184,10 @@ export const ru: Translations = {
     backgroundColor: 'Цвет фона',
     backgroundColorTooltip: 'HEX-цвет фона/полос окна (ex. #1a1a1a). Оставьте пустым для тёмно-серого по умолчанию. (scrcpy v4+)',
     backgroundColorNone: 'По умолчанию',
-    badgeNew: 'НОВОЕ'
+    badgeNew: 'НОВОЕ',
+    // v4.1 features
+    ignoreEncoderConstraints: 'Игнорировать ограничения энкодера',
+    ignoreEncoderConstraintsTooltip: 'Полностью пропустить ограничения размера видеоэнкодера. Используйте, если scrcpy не запускается или возникают проблемы с разрешением из-за некорректных данных об ограничениях, сообщаемых устройством (scrcpy v4.1+).',
   },
 
   sessionBehavior: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -179,7 +179,10 @@ export const zhCN: Translations = {
         backgroundColor: '背景颜色',
         backgroundColorTooltip: '窗口背景/外边区域的十六进制颜色（如 #1a1a1a）。留空则使用默认深灰色。（scrcpy v4+）',
         backgroundColorNone: '默认',
-        badgeNew: '新'
+        badgeNew: '新',
+        // v4.1 features
+        ignoreEncoderConstraints: '忽略编码器限制',
+        ignoreEncoderConstraintsTooltip: '完全跳过视频编码器尺寸限制。如果 scrcpy 因设备报告错误的编码器限制而无法启动或出现分辨率问题，请使用此选项（scrcpy v4.1+）。'
     },
     sessionBehavior: {
         title: '行为设置',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -179,7 +179,10 @@ export const zhTW: Translations = {
         backgroundColor: '背景顏色',
         backgroundColorTooltip: '視窗背景/外邊區域的十六進位顏色（如 #1a1a1a）。留白則使用預設深灰色。（scrcpy v4+）',
         backgroundColorNone: '預設',
-        badgeNew: '新'
+        badgeNew: '新',
+        // v4.1 features
+        ignoreEncoderConstraints: '忽略編碼器限制',
+        ignoreEncoderConstraintsTooltip: '完全跳過視訊編碼器尺寸限制。若因裝置回報錯誤的編碼器限制導致 scrcpy 無法啟動或解析度問題，請使用此項 (scrcpy v4.1+)。',
     },
     sessionBehavior: {
         title: '行為設定',


### PR DESCRIPTION
## Summary
Adds full support and UI compatibility for **scrcpy v4.1**.

### Key Changes
- **VP8 & VP9 Video Codecs**: Added VP8 and VP9 options to the video codec selection dropdowns (both Screen Mirror and Camera modes).
- **Ignore Encoder Constraints**: Added `--ignore-video-encoder-constraints` toggle in the Performance settings, allowing users to bypass encoder size limits when devices report inaccurate constraints.
- **Backend & Config Support**: Updated Tauri Rust backend (`commands.rs`) and TypeScript state (`useScrcpy.ts`) to handle `ignore_video_encoder_constraints`.
- **Localization**: Added translation keys across all 8 supported locale files (`en`, `ar`, `fr`, `id`, `pt-BR`, `ru`, `zh-CN`, `zh-TW`).

### Verification
- Frontend build passed (`vite build` - 0 errors)
- Rust compilation check passed (`cargo check` - 0 errors)
