### PR TITLE
feat(ux): double-click to edit Width/Height/DPI, live ratio lock

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+src-tauri/target
+src-tauri/gen
+package-lock.json
+*.lock

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+    "tabWidth": 4,
+    "useTabs": false,
+    "semi": true,
+    "trailingComma": "all",
+    "arrowParens": "always",
+    "printWidth": 120,
+    "bracketSpacing": true,
+    "endOfLine": "lf"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "autoprefixer": "10.5.0",
         "jsdom": "29.1.0",
         "postcss": "8.5.12",
+        "prettier": "^3.9.6",
         "tailwindcss": "4.2.4",
         "typescript": "6.0.3",
         "vite": "8.0.10",
@@ -2824,6 +2825,22 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "tauri": "tauri",
     "test": "vitest run",
     "lint": "tsc --noEmit",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "build:linux": "NO_STRIP=1 APPIMAGE_EXTRACT_AND_RUN=1 LINUXDEPLOY_EXCLUDE_LIBS=libwayland-client.so.0:libwayland-cursor.so.0:libwayland-egl.so.1:libwayland-server.so.0 npm run tauri build"
   },
   "dependencies": {
@@ -35,6 +37,7 @@
     "autoprefixer": "10.5.0",
     "jsdom": "29.1.0",
     "postcss": "8.5.12",
+    "prettier": "^3.9.6",
     "tailwindcss": "4.2.4",
     "typescript": "6.0.3",
     "vite": "8.0.10",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3236,7 +3236,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrcpy-gui-v3"
-version = "4.0.1"
+version = "4.1.0"
 dependencies = [
  "chrono",
  "flate2",

--- a/src/components/ControlPanel/ControlPanel.test.tsx
+++ b/src/components/ControlPanel/ControlPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ControlPanel from '.';
@@ -30,7 +30,7 @@ function createConfig(overrides: Partial<ScrcpyConfig> = {}): ScrcpyConfig {
 }
 
 function renderControlPanel(config: ScrcpyConfig, support: RenderDriverSupport, setConfig = vi.fn()) {
-    render(
+    const { container } = render(
         <ControlPanel
             config={config}
             setConfig={setConfig}
@@ -43,7 +43,7 @@ function renderControlPanel(config: ScrcpyConfig, support: RenderDriverSupport, 
         />
     );
 
-    return setConfig;
+    return { setConfig, container };
 }
 
 async function openRendererSelect(user: ReturnType<typeof userEvent.setup>) {
@@ -84,7 +84,7 @@ describe('ControlPanel renderer selector', () => {
     describe('when selecting renderers', () => {
         it('updates renderDriver when selecting supported renderer', async () => {
             const user = userEvent.setup();
-            const setConfig = renderControlPanel(createConfig(), supportedRenderers);
+            const { setConfig } = renderControlPanel(createConfig(), supportedRenderers);
             await openRendererSelect(user);
             await user.click(screen.getByText('D3D11 (Direct3D)'));
             expect(setConfig).toHaveBeenCalledWith(expect.objectContaining({ renderDriver: 'direct3d' }));
@@ -92,7 +92,7 @@ describe('ControlPanel renderer selector', () => {
 
         it('clears renderDriver when selecting auto renderer', async () => {
             const user = userEvent.setup();
-            const setConfig = renderControlPanel(createConfig({ renderDriver: 'direct3d' }), supportedRenderers);
+            const { setConfig } = renderControlPanel(createConfig({ renderDriver: 'direct3d' }), supportedRenderers);
             await openRendererSelect(user);
             await user.click(screen.getByText('Auto'));
             expect(setConfig).toHaveBeenCalledWith(expect.objectContaining({ renderDriver: undefined }));
@@ -118,5 +118,173 @@ describe('ControlPanel renderer selector', () => {
             renderControlPanel(createConfig({ sessionMode: 'desktop' }), supportedRenderers);
             expect(screen.getByText('Graphics Renderer')).toBeInTheDocument();
         });
+    });
+});
+
+function renderDesktopPanel(overrides: Partial<ScrcpyConfig> = {}) {
+    const config: ScrcpyConfig = {
+        device: '',
+        sessionMode: 'desktop',
+        vdWidth: 1920,
+        vdHeight: 1080,
+        vdDpi: 420,
+        aspectRatioLock: false,
+        ...overrides
+    };
+    const setConfig = vi.fn();
+
+    const { container } = render(
+        <ControlPanel
+            config={config}
+            setConfig={setConfig}
+            onStart={() => {}}
+            onStop={() => {}}
+            isRunning={false}
+            onListOptions={() => {}}
+        />
+    );
+
+    return {
+        config,
+        setConfig,
+        widthSlider: container.querySelector('.vd-width-slider') as HTMLInputElement,
+        heightSlider: container.querySelector('.vd-height-slider') as HTMLInputElement
+    };
+}
+
+describe('VDSlider (Width / Height / DPI, desktop mode)', () => {
+    it('double-clicking the value swaps in a spinner-free number input with the current value', async () => {
+        const user = userEvent.setup();
+        renderDesktopPanel();
+
+        await user.dblClick(screen.getByText('1920px'));
+
+        // The range input (role "slider") keeps rendering alongside the new
+        // editor, so the number input (role "spinbutton") is the only
+        // unambiguous way to grab it.
+        const input = screen.getByRole('spinbutton');
+        expect(input).toHaveValue(1920);
+        expect(input).toHaveAttribute('type', 'number');
+        expect(input).toHaveClass('no-spinner');
+    });
+
+    it('commits a typed value on Enter', async () => {
+        const user = userEvent.setup();
+        const { setConfig } = renderDesktopPanel();
+
+        await user.dblClick(screen.getByText('1920px'));
+        const input = screen.getByRole('spinbutton');
+        await user.clear(input);
+        await user.type(input, '2400{Enter}');
+
+        expect(setConfig).toHaveBeenCalledWith(expect.objectContaining({ vdWidth: 2400 }));
+        expect(screen.getByText('2400px')).toBeInTheDocument();
+    });
+
+    it('commits a typed value on blur', async () => {
+        const user = userEvent.setup();
+        const { setConfig } = renderDesktopPanel();
+
+        await user.dblClick(screen.getByText('1080px'));
+        const input = screen.getByRole('spinbutton');
+        await user.clear(input);
+        await user.type(input, '900');
+        await user.tab();
+
+        expect(setConfig).toHaveBeenCalledWith(expect.objectContaining({ vdHeight: 900 }));
+    });
+
+    it('clamps a typed value above the max to the slider bound', async () => {
+        const user = userEvent.setup();
+        const { setConfig } = renderDesktopPanel();
+
+        await user.dblClick(screen.getByText('1920px'));
+        const input = screen.getByRole('spinbutton');
+        await user.clear(input);
+        await user.type(input, '99999{Enter}');
+
+        expect(setConfig).toHaveBeenCalledWith(expect.objectContaining({ vdWidth: 3840 }));
+    });
+
+    it('clamps a typed value below the min to the slider bound', async () => {
+        const user = userEvent.setup();
+        const { setConfig } = renderDesktopPanel();
+
+        await user.dblClick(screen.getByText('1920px'));
+        const input = screen.getByRole('spinbutton');
+        await user.clear(input);
+        await user.type(input, '1{Enter}');
+
+        expect(setConfig).toHaveBeenCalledWith(expect.objectContaining({ vdWidth: 480 }));
+    });
+
+    it('cancels editing on Escape without committing', async () => {
+        const user = userEvent.setup();
+        const { setConfig } = renderDesktopPanel();
+
+        await user.dblClick(screen.getByText('1920px'));
+        const input = screen.getByRole('spinbutton');
+        await user.clear(input);
+        await user.type(input, '3000');
+        await user.keyboard('{Escape}');
+
+        expect(setConfig).not.toHaveBeenCalled();
+        expect(screen.getByText('1920px')).toBeInTheDocument();
+    });
+
+    it('ignores a non-numeric typed value instead of committing garbage', async () => {
+        const user = userEvent.setup();
+        const { setConfig } = renderDesktopPanel();
+
+        await user.dblClick(screen.getByText('1920px'));
+        const input = screen.getByRole('spinbutton');
+        await user.clear(input);
+        await user.keyboard('{Enter}');
+
+        expect(setConfig).not.toHaveBeenCalled();
+        expect(screen.getByText('1920px')).toBeInTheDocument();
+    });
+
+    it('reuses the same editable slider for DPI, including its tooltip label', async () => {
+        const user = userEvent.setup();
+        const { setConfig } = renderDesktopPanel();
+
+        expect(screen.getByText('420 DPI')).toBeInTheDocument();
+
+        await user.dblClick(screen.getByText('420 DPI'));
+        const input = screen.getByRole('spinbutton');
+        await user.clear(input);
+        await user.type(input, '300{Enter}');
+
+        expect(setConfig).toHaveBeenCalledWith(expect.objectContaining({ vdDpi: 300 }));
+    });
+});
+
+describe('Aspect ratio lock (desktop mode)', () => {
+    it('updates height live while dragging the width slider, without waiting for release', () => {
+        const { setConfig, widthSlider } = renderDesktopPanel({ aspectRatioLock: true, vdWidth: 1920, vdHeight: 1080 });
+
+        fireEvent.change(widthSlider, { target: { value: '960' } });
+
+        // No mouseup/change-commit event fired: the drag tick alone must propagate.
+        expect(setConfig).toHaveBeenCalledTimes(1);
+        expect(setConfig).toHaveBeenCalledWith(expect.objectContaining({ vdWidth: 960, vdHeight: 540 }));
+    });
+
+    it('updates width live while dragging the height slider, without waiting for release', () => {
+        const { setConfig, heightSlider } = renderDesktopPanel({ aspectRatioLock: true, vdWidth: 1920, vdHeight: 1080 });
+
+        fireEvent.change(heightSlider, { target: { value: '540' } });
+
+        expect(setConfig).toHaveBeenCalledTimes(1);
+        expect(setConfig).toHaveBeenCalledWith(expect.objectContaining({ vdWidth: 960, vdHeight: 540 }));
+    });
+
+    it('leaves the other dimension untouched while dragging when ratio lock is off', () => {
+        const { setConfig, widthSlider } = renderDesktopPanel({ aspectRatioLock: false, vdWidth: 1920, vdHeight: 1080 });
+
+        fireEvent.change(widthSlider, { target: { value: '960' } });
+
+        expect(setConfig).toHaveBeenCalledWith(expect.objectContaining({ vdWidth: 960, vdHeight: 1080 }));
     });
 });

--- a/src/components/ControlPanel/ControlPanel.tsx
+++ b/src/components/ControlPanel/ControlPanel.tsx
@@ -44,7 +44,7 @@ const BitrateControl = ({ label, value, onChange }: { label: string, value: numb
     );
 };
 
-const VDSlider = ({ label, value, min, max, unit = "", tooltip, onChange }: { label: string, value: number, min: number, max: number, unit?: string, tooltip?: string, onChange: (val: number) => void }) => {
+const VDSlider = ({ label, value, min, max, unit = "", tooltip, sliderClassName = "", onChange }: { label: string, value: number, min: number, max: number, unit?: string, tooltip?: string, sliderClassName?: string, onChange: (val: number) => void }) => {
     const { t } = useI18n();
     const [localValue, setLocalValue] = useState(value);
     useEffect(() => setLocalValue(value), [value]);
@@ -104,7 +104,7 @@ const VDSlider = ({ label, value, min, max, unit = "", tooltip, onChange }: { la
                     setLocalValue(val);
                     onChange(val);
                 }}
-                className="w-full h-1 accent-primary bg-zinc-800 rounded-full appearance-none cursor-pointer"
+                className={`w-full h-1 accent-primary bg-zinc-800 rounded-full appearance-none cursor-pointer ${sliderClassName}`}
             />
         </div>
     );
@@ -548,6 +548,7 @@ export default function ControlPanel({
                                         value={config.vdWidth || 1920}
                                         min={480} max={3840}
                                         unit="px"
+                                        sliderClassName="vd-width-slider"
                                         onChange={(val: number) => {
                                             if (config.aspectRatioLock && config.vdWidth && config.vdHeight) {
                                                 const ratio = config.vdHeight / config.vdWidth;
@@ -562,6 +563,7 @@ export default function ControlPanel({
                                         value={config.vdHeight || 1080}
                                         min={360} max={2160}
                                         unit="px"
+                                        sliderClassName="vd-height-slider"
                                         onChange={(val: number) => {
                                             if (config.aspectRatioLock && config.vdWidth && config.vdHeight) {
                                                 const ratio = config.vdWidth / config.vdHeight;
@@ -577,6 +579,7 @@ export default function ControlPanel({
                                         value={config.vdDpi || 420}
                                         min={120} max={640}
                                         unit=" DPI"
+                                        sliderClassName="vd-dpi-slider"
                                         onChange={(val: number) => handleChange('vdDpi', val)}
                                     />
                                     <CustomSelect

--- a/src/components/ControlPanel/ControlPanel.tsx
+++ b/src/components/ControlPanel/ControlPanel.tsx
@@ -44,23 +44,66 @@ const BitrateControl = ({ label, value, onChange }: { label: string, value: numb
     );
 };
 
-const VDSlider = ({ label, value, min, max, unit = "", onChange }: { label: string, value: number, min: number, max: number, unit?: string, onChange: (val: number) => void }) => {
+const VDSlider = ({ label, value, min, max, unit = "", tooltip, onChange }: { label: string, value: number, min: number, max: number, unit?: string, tooltip?: string, onChange: (val: number) => void }) => {
+    const { t } = useI18n();
     const [localValue, setLocalValue] = useState(value);
     useEffect(() => setLocalValue(value), [value]);
+
+    const [isEditing, setIsEditing] = useState(false);
+    const [editValue, setEditValue] = useState(String(value));
+
+    const commitEdit = () => {
+        const parsed = parseInt(editValue, 10);
+        if (!isNaN(parsed)) {
+            const clamped = Math.min(max, Math.max(min, parsed));
+            setLocalValue(clamped);
+            onChange(clamped);
+        }
+        setIsEditing(false);
+    };
 
     return (
         <div className="space-y-1">
             <div className="flex justify-between items-center h-4">
-                <label className="text-[8px] font-black text-zinc-500 uppercase tracking-widest">{label}</label>
-                <span className="text-[10px] font-black text-primary tabular-nums">{localValue}{unit}</span>
+                <div className="flex items-center gap-1.5">
+                    <label className="text-[8px] font-black text-zinc-500 uppercase tracking-widest">{label}</label>
+                    {tooltip && <Tooltip text={tooltip} placement="top" />}
+                </div>
+                {isEditing ? (
+                    <input
+                        type="number"
+                        autoFocus
+                        min={min}
+                        max={max}
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onBlur={commitEdit}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') commitEdit();
+                            else if (e.key === 'Escape') setIsEditing(false);
+                        }}
+                        className="no-spinner w-14 text-[10px] font-black text-primary tabular-nums bg-zinc-800 border border-primary/40 rounded px-1 text-right outline-none"
+                    />
+                ) : (
+                    <span
+                        className="text-[10px] font-black text-primary tabular-nums cursor-text"
+                        onDoubleClick={() => { setEditValue(String(localValue)); setIsEditing(true); }}
+                        title={t('controlPanel.doubleClickToEdit')}
+                    >
+                        {localValue}{unit}
+                    </span>
+                )}
             </div>
             <input
                 type="range"
                 min={min}
                 max={max}
                 value={localValue}
-                onChange={(e) => setLocalValue(parseInt(e.target.value))}
-                onMouseUp={() => onChange(localValue)}
+                onChange={(e) => {
+                    const val = parseInt(e.target.value);
+                    setLocalValue(val);
+                    onChange(val);
+                }}
                 className="w-full h-1 accent-primary bg-zinc-800 rounded-full appearance-none cursor-pointer"
             />
         </div>
@@ -528,23 +571,14 @@ export default function ControlPanel({
                                             }
                                         }}
                                     />
-                                    <div className="space-y-1">
-                                        <div className="flex justify-between items-center h-4">
-                                            <div className="flex items-center gap-1.5">
-                                                <label className="text-[8px] font-black text-zinc-500 uppercase tracking-widest">{t('controlPanel.uiScaling')}</label>
-                                                <Tooltip text={t('controlPanel.uiScalingTooltip')} placement="top" />
-                                            </div>
-                                            <span className="text-[10px] font-black text-primary tabular-nums">{config.vdDpi || 420} DPI</span>
-                                        </div>
-                                        <input
-                                            type="range"
-                                            min={120}
-                                            max={640}
-                                            value={config.vdDpi || 420}
-                                            onChange={(e) => handleChange('vdDpi', parseInt(e.target.value))}
-                                            className="w-full h-1 accent-primary bg-zinc-800 rounded-full appearance-none cursor-pointer"
-                                        />
-                                    </div>
+                                    <VDSlider
+                                        label={t('controlPanel.uiScaling')}
+                                        tooltip={t('controlPanel.uiScalingTooltip')}
+                                        value={config.vdDpi || 420}
+                                        min={120} max={640}
+                                        unit=" DPI"
+                                        onChange={(val: number) => handleChange('vdDpi', val)}
+                                    />
                                     <CustomSelect
                                         label={t('controlPanel.quickPresets')}
                                         value={(() => {

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -160,6 +160,7 @@ export const ar: Translations = {
         ratioLockTitle: 'قفل نسبة العرض',
         width: 'العرض',
         height: 'الارتفاع',
+        doubleClickToEdit: 'انقر نقرًا مزدوجًا لكتابة القيمة',
         uiScaling: 'مقياس الواجهة (DPI)',
         uiScalingTooltip: 'قيمة DPI الأقل تمنح مظهرًا يشبه سطح المكتب أو الجهاز اللوحي، بينما القيمة الأعلى تمنح مظهر الهاتف.',
         quickPresets: 'إعدادات سريعة',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -158,6 +158,7 @@ export const en = {
         ratioLockTitle: 'Lock Aspect Ratio',
         width: 'Width',
         height: 'Height',
+        doubleClickToEdit: 'Double-click to type a value',
         uiScaling: 'UI Scaling (DPI)',
         uiScalingTooltip: 'Lower DPI = Desktop/Tablet feel (larger UI). Higher DPI = Phone feel (smaller, denser UI).',
         quickPresets: 'Quick Presets',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -157,6 +157,7 @@ export const fr: Translations = {
         ratioLockTitle: 'Verrouiller le Format',
         width: 'Largeur',
         height: 'Hauteur',
+        doubleClickToEdit: 'Double-cliquez pour saisir une valeur',
         uiScaling: 'Échelle UI (DPI)',
         uiScalingTooltip: 'DPI plus bas = ambiance Bureau/Tablette (UI plus grande). DPI plus élevé = ambiance Téléphone (UI plus petite, dense).',
         quickPresets: 'Préréglages Rapides',

--- a/src/i18n/locales/id.ts
+++ b/src/i18n/locales/id.ts
@@ -157,6 +157,7 @@ languages: {
         ratioLockTitle: 'Kunci Rasio Aspek',
         width: 'Lebar',
         height: 'Tinggi',
+        doubleClickToEdit: 'Klik dua kali untuk mengetik nilai',
         uiScaling: 'Skala UI (DPI)',
         uiScalingTooltip: 'DPI lebih rendah = nuansa Desktop/Tablet (UI lebih besar). DPI lebih tinggi = nuansa Ponsel (UI lebih kecil dan padat).',
         quickPresets: 'Preset Cepat',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -157,6 +157,7 @@ export const ptBR: Translations = {
         ratioLockTitle: 'Travar Proporção de Tela',
         width: 'Largura',
         height: 'Altura',
+        doubleClickToEdit: 'Clique duas vezes para digitar um valor',
         uiScaling: 'Escala da UI (DPI)',
         uiScalingTooltip: 'DPI menor = sensação de Desktop/Tablet (UI maior). DPI maior = sensação de Telefone (UI menor e mais densa).',
         quickPresets: 'Predefinições Rápidas',

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -162,6 +162,7 @@ export const ru: Translations = {
     ratioLockTitle: 'Зафиксировать соотношение сторон',
     width: 'Ширина',
     height: 'Высота',
+    doubleClickToEdit: 'Дважды щёлкните, чтобы ввести значение',
     uiScaling: 'Масштаб интерфейса (DPI)',
     uiScalingTooltip: 'Ниже DPI = вид как на десктопе/планшете (крупнее интерфейс).\nВыше DPI = вид как на телефоне (меньше и плотнее интерфейс).',
     quickPresets: 'Быстрые пресеты',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -157,6 +157,7 @@ export const zhCN: Translations = {
         ratioLockTitle: '锁定画面比例',
         width: '宽',
         height: '高',
+        doubleClickToEdit: '双击以输入数值',
         uiScaling: 'UI 缩放 (DPI)',
         uiScalingTooltip: 'DPI 越低界面越大，DPI 越高界面越小。',
         quickPresets: '快速预设',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -157,6 +157,7 @@ export const zhTW: Translations = {
         ratioLockTitle: '鎖定畫面比例',
         width: '寬',
         height: '高',
+        doubleClickToEdit: '雙擊以輸入數值',
         uiScaling: 'UI 縮放 (DPI)',
         uiScalingTooltip: '低 DPI = 大 UI，高 DPI = 小 UI。',
         quickPresets: '快速預設',

--- a/src/index.css
+++ b/src/index.css
@@ -163,6 +163,17 @@ body {
 [data-mode='light'] .custom-range::-webkit-slider-thumb { border-color: #fafaf9; }
 [data-mode='light'] .custom-range::-moz-range-thumb     { border-color: #fafaf9; }
 
+/* Hide native number input spin buttons (kept: arrow-key increment still works) */
+.no-spinner::-webkit-outer-spin-button,
+.no-spinner::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.no-spinner {
+  appearance: textfield;
+}
+
 /* ── .force-dark: element stays dark regardless of mode ─── */
 /* Used on the terminal/log panel so it always looks like a dark terminal. */
 [data-mode='light'] .force-dark,


### PR DESCRIPTION
## Summary
This PR lets you type an exact Width, Height, or DPI value in Desktop capture mode instead of only dragging, and fixes Ratio Lock so the paired dimension updates live while dragging instead of only on release.

## What Changed

### 1) UX: Editable slider values (Width / Height / DPI)
- Double-click the Width, Height, or DPI value in Desktop capture mode to swap it for a text input and type an exact value.
- The typed value commits on Enter or on blur, is clamped to the slider's min/max, and Escape cancels without committing.
- Native number-input spinner arrows are hidden with a new `.no-spinner` CSS utility (arrow-key increment on the input still works).
- Added a `controlPanel.doubleClickToEdit` tooltip string to all 8 locales.

### 2) Fix: Ratio Lock now updates live while dragging
- Previously, dragging Width or Height with Ratio Lock on only updated the paired dimension after releasing the slider (on `mouseup`).
- The slider now fires its update on every drag tick, so the locked dimension follows in real time.

### 3) Refactor: DPI slider reuses the shared VDSlider component
- The DPI control was a bespoke inline `<input type="range">`; it now reuses `VDSlider` (the same component as Width/Height), picking up double-click editing for free.
- Added an optional `tooltip` prop (for the existing DPI info tooltip) and a `sliderClassName` prop (for stable per-slider selectors: `vd-width-slider` / `vd-height-slider` / `vd-dpi-slider`) to `VDSlider`.

### 4) Tests
- Added 11 tests in `ControlPanel.test.tsx` covering double-click editing, typed-value commit/cancel/clamp behavior, and the live Ratio Lock update, alongside the existing renderer-selector suite.

### 5) Tooling: Prettier added, not yet applied
- Added `prettier` as a dev dependency with a base `.prettierrc.json` / `.prettierignore` and `format` / `format:check` npm scripts.
- No repo-wide formatting run is included in this PR — that's left for a separate change so this diff stays reviewable.

## Commits Included
- feat(ux): add double clicking on resolution and DPI values in Desktop capture
- test(control-panel): add tests for slider editing and ratio lock
- chore(tooling): add prettier and base config

## Validation Performed
- `npm run lint` (tsc --noEmit)
- `npm test` — 32 passed (20 in ControlPanel, 12 in Sidebar)
- `npm run build`

## Recordings

### Desktop capture — Width/Height/DPI editing
<img width="763" height="693" alt="Screencast_compressed" src="https://github.com/user-attachments/assets/15479aa4-3538-4b0c-b82d-15e9adfdfbab" />

## Notes
- `npm run format` will produce a large repo-wide diff once run (quote style, wrapping); intentionally not part of this PR.
